### PR TITLE
sass loader가 아닌 css-in-js 라이브러리를 사용

### DIFF
--- a/src/frontend/babel.config.js
+++ b/src/frontend/babel.config.js
@@ -4,6 +4,7 @@ module.exports = (isEnvDevelopment) => ({
     '@babel/preset-react',
   ],
   plugins: [
+    'babel-plugin-styled-components',
     isEnvDevelopment && 'react-hot-loader/babel',
   ].filter(Boolean),
 });

--- a/src/frontend/components/Login/Login.jsx
+++ b/src/frontend/components/Login/Login.jsx
@@ -1,8 +1,14 @@
 import React from 'react';
+import styled from 'styled-components';
+
+const Button = styled.button`
+  background-color: yellow;
+`;
 
 const Login = () => (
   <div className='login'>
     Login~~
+    <Button>ㅋㅋ</Button>
   </div>
 );
 

--- a/src/frontend/components/Login/Login.scss
+++ b/src/frontend/components/Login/Login.scss
@@ -1,3 +1,0 @@
-.login {
-  color: red;
-}

--- a/src/frontend/components/Login/index.js
+++ b/src/frontend/components/Login/index.js
@@ -1,3 +1,1 @@
-import './Login.scss';
-
 export { default } from './Login.jsx';

--- a/src/frontend/webpack.config.js
+++ b/src/frontend/webpack.config.js
@@ -44,14 +44,6 @@ module.exports = (webpackEnv) => {
             options: babelConfig(isEnvDevelopment),
           },
         },
-        {
-          test: /\.(scss|sass)$/,
-          use: [
-            'style-loader',
-            'css-loader',
-            'sass-loader',
-          ],
-        },
       ],
     },
     ...(isEnvDevelopment ? {


### PR DESCRIPTION
Lucas FE 요구사항
> 스타일작업은 'css in js' 방식의 라이브러리를 사용한다.

준수를 위해 `styled components` 라이브러리 차용. 이에 기존 scss 모듈 및 로더, 파일은 제거함.

`styled components`의 사용 예시는 https://velog.io/@velopert/react-component-styling 참고
공식문서: https://styled-components.com/docs