### PR TITLE
chore: lint CLI명령어 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "npx webpack --config=./src/backend/webpack.config.js --mode=production && npx webpack --config=./src/frontend/webpack.config.js --env=production",
     "watch": "npx webpack --watch --config=./src/backend/webpack.config.js --mode=development",
+    "lint": "npx eslint --ext .js,.jsx --fix src",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
## usage
```bash
npm run lint
```

## 사용 예시
![image](https://user-images.githubusercontent.com/48747221/97516756-2d15d280-19d7-11eb-8ac9-910aa7a1e8c7.png)

- warning이나 error가 발생해도 발생한 부분 이외에서의 linting은 정상적으로 동작합니다.
- `console.log`나 `alert`이 기본 warning으로 되어있는데 거슬린다면 `.eslintrc.json`파일에서 rule을 `off`로 하면 콘솔에는 보이지 않게 됩니다.
- `import/no-extraneous-dependencies` error는 백엔드 devserver에서 `devDependencies`를 import해서 생긴 에러인데 dev environment에서만 import가 발생하게 되어있어서 문제 여지는 없습니다.
- `react/prop-types` error는 #41 확인 부탁이요