### PR TITLE
feat: globalStyle 적용

### DIFF
--- a/src/frontend/index.js
+++ b/src/frontend/index.js
@@ -3,13 +3,14 @@ import ReactDOM from 'react-dom';
 import { ThemeProvider } from 'styled-components';
 import { BrowserRouter } from 'react-router-dom';
 
-import theme from './theme';
+import { theme, GlobalStyle } from './theme';
 import App from './components/App.jsx';
 
 ReactDOM.render(
   <BrowserRouter>
     <ThemeProvider theme={theme}>
       <App />
+      <GlobalStyle />
     </ThemeProvider>
   </BrowserRouter>,
   document.getElementById('root'),

--- a/src/frontend/resources/index.html
+++ b/src/frontend/resources/index.html
@@ -5,17 +5,6 @@
   <meta http-equiv='X-UA-Compatible' content='IE=edge'>
   <title>Issue Tracker-20</title>
   <meta name='viewport' content='width=device-width, initial-scale=1'>
-  <style>
-    html, body {
-      margin: 0;
-      padding: 0;
-      border: 0;
-      font-size: 100%;
-      font: inherit;
-      vertical-align: baseline;
-      min-height: 100vh;
-    }
-  </style>
 </head>
 <body>
   <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/frontend/theme/index.js
+++ b/src/frontend/theme/index.js
@@ -1,4 +1,24 @@
-export default {
+import { createGlobalStyle } from 'styled-components';
+
+export const GlobalStyle = createGlobalStyle`
+  html, body {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
+    min-height: 100vh;
+  }
+  button {
+    border: none;
+    &:not(:disabled) {
+      cursor: pointer;
+    }
+  }
+`;
+
+export const theme = {
   mainColor: '',
   textColor: '#212121',
 };


### PR DESCRIPTION
`index.html`에 적용했던 style을 css-in-js형태로 적용. 

### 사용 예시
`/src/frontend/theme/index.js`의 `GlobalStyle` 내역 수정 시 적용

### Linked issues
- Closes #35.
