### PR TITLE
이슈 목록 조회 페이지 CSS 수정

### DIFF
--- a/src/frontend/components/App.jsx
+++ b/src/frontend/components/App.jsx
@@ -5,6 +5,7 @@ import {
   Route,
 } from 'react-router-dom';
 import LoginPage from './Login';
+import IssuePage from './Issue';
 import Main from './Main';
 import PrivateRoute from './PrivateRoute';
 
@@ -15,7 +16,7 @@ const App = () => {
       <div>
         <Switch>
           <PrivateRoute exact path="/">
-            <Main />
+            <IssuePage />
           </PrivateRoute>
           <Route path="/login" component={LoginPage} />
         </Switch>

--- a/src/frontend/components/Common/Button.js
+++ b/src/frontend/components/Common/Button.js
@@ -34,10 +34,13 @@ const CustomButton = styled.button`
     }
     return props.theme.whiteColor;
   }};
+  border: 1px solid ${(props) => (props.theme.buttonBorderColor)};
+  border-radius: 6px;
+  padding: 0.4rem;
 
-  border-radius: 5px;
-
-  padding: 0.8rem;
+  &:hover {
+    background-color: ${(props) => (props.theme.buttonHoverColor)};
+  }
 `;
 
 export default Button;

--- a/src/frontend/components/Issue/IssuePage.jsx
+++ b/src/frontend/components/Issue/IssuePage.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 
+import Button from '../Common/Button';
+
 const FlexColumnBox = `
   display: flex;
   flex-flow: column;
@@ -48,7 +50,7 @@ const FlexColumnBar = styled.div`
 
 const FilterButton = styled.button`
   width: 10%;
-  border: 1px solid #1b1f2326;
+  border: 1px solid ${(props) => (props.theme.grayBorderColor)};
   border-top-left-radius: 6px;
   border-bottom-left-radius: 6px;
   background-color: ${(props) => (props.theme.grayButtonColor)};
@@ -65,7 +67,7 @@ const FilterButton = styled.button`
 `;
 
 const FilterInputBox = styled.input`
-  width: 40%;
+  width: 43%;
   border: 1px solid ${(props) => (props.theme.inputBorderColor)};
   background-color: ${(props) => (props.theme.inputBgColor)};
   border-top-right-radius: 6px;
@@ -83,16 +85,34 @@ const FilterInputBox = styled.input`
 `;
 
 const LabelsButton = styled.button`
-  width: 20%;
+  width: 15%;
+  border: 1px solid ${(props) => (props.theme.grayBorderColor)};
+  background-color: ${(props) => (props.theme.whiteButtonColor)};
+  border-top-left-radius: 6px;
+  border-bottom-left-radius: 6px;
+
+  &:hover {
+    background-color: ${(props) => (props.theme.whiteButtonHoverColor)};
+  }
 `;
 
 const MilestonesButton = styled.button`
-  width: 20%;
+  width: 15%;
+  border: 1px solid ${(props) => (props.theme.grayBorderColor)};
+  background-color: ${(props) => (props.theme.whiteColor)};
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
+  margin-left: -1px;
+  margin-right: 1em;
+
+  &:hover {
+    background-color: ${(props) => (props.theme.whiteButtonHoverColor)};
+  }
 `;
 
-const CreateIssueButton = styled.button`
+const CreateIssueButton = styled(Button)`
   margin-left: 1em;
-  width: 10%;
+  width: 20%;
 `;
 
 const SortMenuBar = styled.div`
@@ -126,7 +146,7 @@ const Issue = () => (
         <FilterInputBox placeholder='필터를 입력해주세요'></FilterInputBox>
         <LabelsButton>Labels</LabelsButton>
         <MilestonesButton>Milestones</MilestonesButton>
-        <CreateIssueButton>new Issue</CreateIssueButton>
+        <CreateIssueButton type="confirm" text="New Issue"></CreateIssueButton>
       </FlexRowBar>
       <FlexColumnBar>
         <SortMenuBar>

--- a/src/frontend/components/Issue/IssuePage.jsx
+++ b/src/frontend/components/Issue/IssuePage.jsx
@@ -22,7 +22,7 @@ const Topbar = styled.div`
   ${FlexRowBox}
   width: 100%;
   height: 50px;
-  background-color: #24292e;
+  background-color: ${(props) => { return props.theme.headerColor }};
   align-items: center;
   justify-content: center;
   color: white;
@@ -48,11 +48,38 @@ const FlexColumnBar = styled.div`
 
 const FilterButton = styled.button`
   width: 10%;
+  border: 1px solid #1b1f2326;
+  border-top-left-radius: 6px;
+  border-bottom-left-radius: 6px;
+  background-color: ${(props) => (props.theme.grayButtonColor)};
+
+  &:hover {
+    background-color: ${(props) => (props.theme.grayButtonHoverColor)};
+    z-index: 1;
+  }
+
+  &:active {
+    background-color: ${(props) => (props.theme.grayButtonFocusColor)};
+    z-index: 1;
+  }
 `;
 
 const FilterInputBox = styled.input`
   width: 40%;
+  border: 1px solid ${(props) => (props.theme.inputBorderColor)};
+  background-color: ${(props) => (props.theme.inputBgColor)};
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
   margin-right: 1em;
+  margin-left: -1px;
+  padding-left: 1em;
+
+  &:focus {
+    background-color: ${(props) => (props.theme.whiteColor)};
+    border: 1px solid ${(props) => (props.theme.inputBorderActiveColor)};
+    box-shadow:  0 0 0 3px ${(props) => (props.theme.inputShadowColor)};
+    z-index: 1;
+  }
 `;
 
 const LabelsButton = styled.button`
@@ -74,6 +101,7 @@ const SortMenuBar = styled.div`
   background-color #f6f8fa;
   padding: 10px;
   box-sizing: border-box;
+  justify-content: space-between;
   width: 100%;
   height: 40px;
 `;
@@ -83,6 +111,10 @@ const SortMenuButton = styled.button`
   border:none;
   cursor: pointer;
   background-color: transparent;
+`;
+
+const SortMenuBox = styled.div`
+  ${FlexRowBox}
 `;
 
 const Issue = () => (
@@ -99,12 +131,14 @@ const Issue = () => (
       <FlexColumnBar>
         <SortMenuBar>
           <input type='checkbox'></input>
-          <SortMenuButton>Author</SortMenuButton>
-          <SortMenuButton>Label</SortMenuButton>
-          <SortMenuButton>Projects</SortMenuButton>
-          <SortMenuButton>Milestones</SortMenuButton>
-          <SortMenuButton>Assignee</SortMenuButton>
-          <SortMenuButton>Sort</SortMenuButton>
+          <SortMenuBox>
+            <SortMenuButton>Author</SortMenuButton>
+            <SortMenuButton>Label</SortMenuButton>
+            <SortMenuButton>Projects</SortMenuButton>
+            <SortMenuButton>Milestones</SortMenuButton>
+            <SortMenuButton>Assignee</SortMenuButton>
+            <SortMenuButton>Sort</SortMenuButton>
+          </SortMenuBox>
         </SortMenuBar>
       </FlexColumnBar>
     </Content>

--- a/src/frontend/components/Issue/IssuePage.jsx
+++ b/src/frontend/components/Issue/IssuePage.jsx
@@ -115,13 +115,16 @@ const CreateIssueButton = styled(Button)`
 
 const SortMenuBar = styled.div`
   ${FlexRowBox}
-  margin-top: 1em;
-  background-color #f6f8fa;
-  padding: 10px;
+  margin-top: 1rem;
+  background-color: ${(props) => (props.theme.menuBarBgColor)};
+  padding: 0.6rem;
   box-sizing: border-box;
   justify-content: space-between;
   width: 100%;
   height: 40px;
+  border: 1px solid ${(props) => (props.theme.menuBarBorderColor)};
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
 `;
 
 const SortMenuButton = styled.button`

--- a/src/frontend/components/Issue/IssuePage.jsx
+++ b/src/frontend/components/Issue/IssuePage.jsx
@@ -41,6 +41,7 @@ const FlexRowBar = styled.div`
   ${FlexRowBox}
   width: 100%;
   height: 30px;
+  justify-content: space-between;
 `;
 
 const FlexColumnBar = styled.div`
@@ -49,7 +50,7 @@ const FlexColumnBar = styled.div`
 `;
 
 const FilterButton = styled.button`
-  width: 10%;
+  width: 5rem;
   border: 1px solid ${(props) => (props.theme.grayBorderColor)};
   border-top-left-radius: 6px;
   border-bottom-left-radius: 6px;
@@ -67,14 +68,13 @@ const FilterButton = styled.button`
 `;
 
 const FilterInputBox = styled.input`
-  width: 43%;
+  width: 20rem;
   border: 1px solid ${(props) => (props.theme.inputBorderColor)};
   background-color: ${(props) => (props.theme.inputBgColor)};
   border-top-right-radius: 6px;
   border-bottom-right-radius: 6px;
-  margin-right: 1em;
+  padding-left: 0.5rem;
   margin-left: -1px;
-  padding-left: 1em;
 
   &:focus {
     background-color: ${(props) => (props.theme.whiteColor)};
@@ -85,7 +85,7 @@ const FilterInputBox = styled.input`
 `;
 
 const LabelsButton = styled.button`
-  width: 15%;
+  width: 8rem;
   border: 1px solid ${(props) => (props.theme.grayBorderColor)};
   background-color: ${(props) => (props.theme.whiteButtonColor)};
   border-top-left-radius: 6px;
@@ -97,22 +97,20 @@ const LabelsButton = styled.button`
 `;
 
 const MilestonesButton = styled.button`
-  width: 15%;
+  width: 8rem;
   border: 1px solid ${(props) => (props.theme.grayBorderColor)};
   background-color: ${(props) => (props.theme.whiteColor)};
   border-top-right-radius: 6px;
   border-bottom-right-radius: 6px;
-  margin-left: -1px;
-  margin-right: 1em;
 
+  margin-left: -1px;
   &:hover {
     background-color: ${(props) => (props.theme.whiteButtonHoverColor)};
   }
 `;
 
 const CreateIssueButton = styled(Button)`
-  margin-left: 1em;
-  width: 20%;
+  width: 10rem;
 `;
 
 const SortMenuBar = styled.div`
@@ -133,7 +131,7 @@ const SortMenuButton = styled.button`
   background-color: transparent;
 `;
 
-const SortMenuBox = styled.div`
+const MenuBox = styled.div`
   ${FlexRowBox}
 `;
 
@@ -142,23 +140,27 @@ const Issue = () => (
     <Topbar>ISSUE CRACKER</Topbar>
     <Content>
       <FlexRowBar>
-        <FilterButton>Filters</FilterButton>
-        <FilterInputBox placeholder='필터를 입력해주세요'></FilterInputBox>
-        <LabelsButton>Labels</LabelsButton>
-        <MilestonesButton>Milestones</MilestonesButton>
+        <MenuBox>
+          <FilterButton>Filters</FilterButton>
+          <FilterInputBox placeholder='필터를 입력해주세요'></FilterInputBox>
+        </MenuBox>
+        <MenuBox>
+          <LabelsButton>Labels</LabelsButton>
+          <MilestonesButton>Milestones</MilestonesButton>
+        </MenuBox>
         <CreateIssueButton type="confirm" text="New Issue"></CreateIssueButton>
       </FlexRowBar>
       <FlexColumnBar>
         <SortMenuBar>
           <input type='checkbox'></input>
-          <SortMenuBox>
+          <MenuBox>
             <SortMenuButton>Author</SortMenuButton>
             <SortMenuButton>Label</SortMenuButton>
             <SortMenuButton>Projects</SortMenuButton>
             <SortMenuButton>Milestones</SortMenuButton>
             <SortMenuButton>Assignee</SortMenuButton>
             <SortMenuButton>Sort</SortMenuButton>
-          </SortMenuBox>
+          </MenuBox>
         </SortMenuBar>
       </FlexColumnBar>
     </Content>

--- a/src/frontend/theme/index.js
+++ b/src/frontend/theme/index.js
@@ -12,18 +12,29 @@ export const GlobalStyle = createGlobalStyle`
   }
   button {
     border: none;
+    outline: none;
     &:not(:disabled) {
       cursor: pointer;
     }
+  }
+  input {
+    outline: none;
   }
 `;
 
 export const theme = {
   mainColor: '',
+  grayButtonColor: '#fafbfc',
+  grayButtonHoverColor: '#f3f4f6',
+  grayButtonFocusColor: '#1b1f2326',
+  inputBorderColor: "#e1e4e8",
+  inputBorderActiveColor: "#0366d6",
+  inputShadowColor: '#0366d64d',
+  inputBgColor: '#fafbfc',
   textColor: '#212121',
   headerColor: '#24292e',
   buttonColor: '#009900',
   unActiveButtonColor: '#99CC99',
   subButtonColor: '#eee',
-  whiteColor: '#eee',
+  whiteColor: '#ffffff',
 };

--- a/src/frontend/theme/index.js
+++ b/src/frontend/theme/index.js
@@ -24,16 +24,25 @@ export const GlobalStyle = createGlobalStyle`
 
 export const theme = {
   mainColor: '',
+  grayBorderColor: '#1b1f2326',
   grayButtonColor: '#fafbfc',
   grayButtonHoverColor: '#f3f4f6',
   grayButtonFocusColor: '#1b1f2326',
+
+  whiteButtonColor: '#ffffff',
+  whiteButtonHoverColor: '#fafbfc',
+
   inputBorderColor: "#e1e4e8",
   inputBorderActiveColor: "#0366d6",
   inputShadowColor: '#0366d64d',
   inputBgColor: '#fafbfc',
+
   textColor: '#212121',
   headerColor: '#24292e',
-  buttonColor: '#009900',
+  buttonColor: '#2ea44f',
+  buttonBorderColor: '#1b1f2326',
+  buttonHoverColor: '#278a43',
+
   unActiveButtonColor: '#99CC99',
   subButtonColor: '#eee',
   whiteColor: '#ffffff',

--- a/src/frontend/theme/index.js
+++ b/src/frontend/theme/index.js
@@ -43,6 +43,8 @@ export const theme = {
   buttonBorderColor: '#1b1f2326',
   buttonHoverColor: '#278a43',
 
+  menuBarBgColor: '#f6f8fa',
+  menuBarBorderColor: '#e1e4e8',
   unActiveButtonColor: '#99CC99',
   subButtonColor: '#eee',
   whiteColor: '#ffffff',


### PR DESCRIPTION
# ToDo : 이슈 목록 조회 페이지 틀 작업
## 변경 전
<img width="840" alt="스크린샷 2020-11-03 오후 1 37 12" src="https://user-images.githubusercontent.com/55074799/97960298-8a08f280-1df4-11eb-8893-fd8e7ee06a1a.png">

## 변경 후
- 빨간색 : flex-row, space-between
- 초록색 : flex-column
- 파란색 : div 태그로 묶인 컴포넌트
<img width="889" alt="스크린샷 2020-11-03 오후 4 31 51" src="https://user-images.githubusercontent.com/55074799/97960307-8e351000-1df4-11eb-8542-22af94a9038f.png">

## 주요 변경점
- 메인 페이지를 기존 테스트 페이지에서 개발중인 Issue 목록 페이지로 변경
- 가로 값으로 px 대신 rem을 사용하기 위해 변경하는 작업 진행
  - (참고) 아직 px를 사용하는 컴포넌트들 다수 존재
- 초록색 버튼 컴포넌트 재사용
- theme에 다수의 색상 추가
- hover 및 focus 속성 추가
