### PR TITLE
feat(GET /issues): 필터 기능 BE 대응, labelCount/milestoneCount 추가

### DIFF
--- a/src/backend/controllers/issues.js
+++ b/src/backend/controllers/issues.js
@@ -100,22 +100,31 @@ export const getAllIssues = async (req, res) => {
     });
     const filteredIssues = foundIssues.filter(filterPivotTable(labelString, assigneeString));
 
+    const labelCount = await db.Label.count();
+    const milestoneCount = await db.Milestone.count();
+
     const invalidContent = filteredIssues.length && filteredIssues.some((issue) => issue.get('commentCount') < 0);
     if (invalidContent) {
       res.status(500).json({
         message: 'content가 없는 issue가 있습니다.',
         issues: filteredIssues,
+        labelCount,
+        milestoneCount,
       });
     } else {
       res.json({
         message: 'success',
         issues: filteredIssues,
+        labelCount,
+        milestoneCount,
       });
     }
   } catch (err) {
     res.status(500).json({
       message: `${err}`,
       issues: [],
+      labelCount: 0,
+      milestoneCount: 0,
     });
   }
 };

--- a/src/backend/controllers/issues.js
+++ b/src/backend/controllers/issues.js
@@ -38,7 +38,7 @@ export const getAllIssues = async (req, res) => {
   const openCondition = parseOpenCondition(isOpenedString);
 
   try {
-    const result = await db.Issue.findAll({
+    const foundIssues = await db.Issue.findAll({
       attributes: [
         'id', 'title', 'isOpened', 'createDate',
         [db.Sequelize.literal('(SELECT COUNT(`comments`.`id`)-1)'), 'commentCount'],
@@ -98,7 +98,7 @@ export const getAllIssues = async (req, res) => {
         db.Sequelize.col('labels.id'),
       ],
     });
-    const filteredIssues = result.filter(filterPivotTable(labelString, assigneeString));
+    const filteredIssues = foundIssues.filter(filterPivotTable(labelString, assigneeString));
 
     const invalidContent = filteredIssues.length && filteredIssues.some((issue) => issue.get('commentCount') < 0);
     if (invalidContent) {

--- a/src/backend/controllers/issues.js
+++ b/src/backend/controllers/issues.js
@@ -1,35 +1,90 @@
 import db from '../models';
 
+const parseOpenCondition = (isOpenedString) => {
+  switch (isOpenedString) {
+    case 'closed': return false;
+    case 'all': return [true, false];
+    default: return true;
+  }
+};
+
+const labelFilter = (labels, title) => labels.some((label) => label.title === title);
+const assigneeFilter = (assignees, name) => assignees.some((assignee) => assignee.username === name);
+const filterPivotTable = (labelString, assigneeString) => (issue) => {
+  const { labels, assignees } = issue;
+  const labelArray = labelString.split(',').filter((label) => label.length);
+  const assigneeArray = assigneeString.split(',').filter((assignee) => assignee.length);
+
+  const validateLabels = labelArray.every((title) => labelFilter(labels, title));
+  const validateAssignees = assigneeArray.every((username) => assigneeFilter(assignees, username));
+  return (labelString === '' || validateLabels) && (assigneeString === '' || validateAssignees);
+};
+
 export const getAllIssues = async (req, res) => {
-  // TODO: 필터에 따른 처리
+  /* query params
+   * is: 'closed' | 'all' ('open' otherwise)
+   * author: username (search all otherwise)
+   * labels: label1,label2 (search all otherwise)
+   * milestone: title (search all otherwise)
+   * assignees: username1,username2 (search all otherwise)
+   */
+  const {
+    is: isOpenedString = '',
+    author: authorUsername = '',
+    labels: labelString = '',
+    milestone: milestoneTitle = '',
+    assignees: assigneeString = '',
+  } = req.query;
+  const openCondition = parseOpenCondition(isOpenedString);
+
   try {
     const result = await db.Issue.findAll({
       attributes: [
         'id', 'title', 'isOpened', 'createDate',
         [db.Sequelize.literal('(SELECT COUNT(`comments`.`id`)-1)'), 'commentCount'],
       ],
+      ...(isOpenedString !== 'all' ? {
+        where: {
+          isOpened: openCondition,
+        },
+      } : {}),
       include: [
         {
           model: db.User,
           as: 'author',
           attributes: ['id', 'username'],
+          ...(authorUsername !== '' ? {
+            where: {
+              username: authorUsername,
+            },
+          } : {}),
         },
         {
           model: db.Milestone,
           as: 'milestone',
           attributes: ['id', 'title'],
+          ...(milestoneTitle !== '' ? {
+            where: {
+              title: milestoneTitle,
+            },
+          } : {}),
         },
         {
           model: db.User,
           as: 'assignees',
           attributes: ['id', 'username', 'profilePictureURL'],
-          through: 'Assignee',
+          through: {
+            as: 'Assignee',
+          },
         },
         {
           model: db.Label,
           as: 'labels',
-          attributes: ['id', 'description', 'color'],
-          through: 'IssueLabel',
+          attributes: ['id', 'title', 'description', 'color'],
+          through: {
+            as: 'IssueLabel',
+            attributes: [],
+          },
         },
         {
           model: db.Comment,
@@ -43,17 +98,18 @@ export const getAllIssues = async (req, res) => {
         db.Sequelize.col('labels.id'),
       ],
     });
+    const filteredIssues = result.filter(filterPivotTable(labelString, assigneeString));
 
-    const invalidContent = result.length && result.some((issue) => issue.get('commentCount') < 0);
+    const invalidContent = filteredIssues.length && filteredIssues.some((issue) => issue.get('commentCount') < 0);
     if (invalidContent) {
       res.status(500).json({
         message: 'content가 없는 issue가 있습니다.',
-        issues: result,
+        issues: filteredIssues,
       });
     } else {
       res.json({
         message: 'success',
-        issues: result,
+        issues: filteredIssues,
       });
     }
   } catch (err) {


### PR DESCRIPTION
### query 명세
```
/* query params
 * is: 'closed' | 'all' ('open' otherwise)
 * author: username (search all otherwise)
 * labels: label1,label2 (search all otherwise)
 * milestone: title (search all otherwise)
 * assignees: username1,username2 (search all otherwise)
 */
```

#### 예시
```
GET /api/issues  // open된 모든 issue들 받아옴.
GET /api/issues?is=all  // open, close된 모든 issue들 받아옴.
GET /api/issues?is=closed  // close된 모든 issue들 받아옴.
GET /api/issues?is=open  // open된 모든 issue들 받아옴.
GET /api/issues?is=asdf  // open된 모든 issue들 받아옴.
GET /api/issues?is=  // open된 모든 issue들 받아옴.

GET /api/issues?author=github  // username github가 생성한 모든 issue들 받아옴.
GET /api/issues?author=  // username 관계없이 모든 issue들 받아옴.

GET /api/issues?labels=frontend  // frontend label을 포함하는 모든 issue들 받아옴.
GET /api/issues?labels=frontend,backend  // frontend와 backend label을 모두 포함하는 모든 issue들 받아옴.
GET /api/issues?labels=  // label 관계없이 모든 issue들 받아옴.
GET /api/issues?labels=,,,,  // label 관계없이 모든 issue들 받아옴.

GET /api/issues?is=closed&author=IU&labels=frontend,backend&assignees=github,crong,JK
// query param간의 순서는 관계없음

GET /api/issues?is=&author=&labels=&assignees=
// 아무것도 입력되지 않으면 모든 issue들 받아옴.
```

### API response 추가
- labelCount: label badge에 들어가야하는 라벨 개수 (type: Number)
- milestoneCount: milestone badge에 들어가야하는 마일스톤 개수 (type: Number)