### PR TITLE
유효하지 않은 토큰일 때 로그인 페이지로 이동하지 않는 것 수정

### DIFF
--- a/src/frontend/components/PrivateRoute/PrivateRoute.jsx
+++ b/src/frontend/components/PrivateRoute/PrivateRoute.jsx
@@ -1,25 +1,50 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Route,
   Redirect,
 } from 'react-router-dom';
 import auth from '@Util/auth';
 
-const PrivateRoute = ({ children, ...rest }) => (
-    <Route
-        {...rest}
-        render={({ location }) => (auth.isAuthenticated() ? (
-          children
-        ) : (
-                <Redirect
-                    to={{
-                      pathname: '/login',
-                      state: { from: location },
-                    }}
-                />
-        ))
+const PrivateRoute = ({ children, ...rest }) => {
+  const [authenticated, setAuthenticated] = useState(true);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (loading === false) {
+      (async function () {
+        try {
+          /* Update effect logic to track correct state */
+          const isUserLogged = await auth.isAuthenticated();
+          setAuthenticated(isUserLogged);
+          setLoading(true);
+        } catch (e) {
+          setAuthenticated(false);
+          setLoading(true);
         }
+      }());
+    }
+  }, []);
+
+  if (!loading) {
+    return (<div></div>);
+  }
+
+  return (
+  <Route
+      {...rest}
+      render={({ location }) => (authenticated ? (
+        children
+      ) : (
+        <Redirect
+            to={{
+              pathname: '/login',
+              state: { from: location },
+            }}
+        />
+      ))
+      }
     />
-);
+  );
+};
 
 export default PrivateRoute;


### PR DESCRIPTION
auth.isAuthenticated가 Promise를 리턴해서 나는 이슈였음. 

## 참고
https://stackoverflow.com/questions/60124524/reactjs-render-private-route-if-authenticated-after-promise-resolved/60124578#60124578

### Linked issue
closes #110 