### PR TITLE
라벨 페이지 완성

### DIFF
--- a/src/frontend/components/LabelPage/LabelFetchDispatcher.jsx
+++ b/src/frontend/components/LabelPage/LabelFetchDispatcher.jsx
@@ -1,0 +1,6 @@
+import { createContext, useContext } from 'react';
+
+const LabelFetchDispatcher = createContext();
+
+export const useLabelFetchDispatcher = () => useContext(LabelFetchDispatcher);
+export default LabelFetchDispatcher;

--- a/src/frontend/components/LabelPage/LabelForm.jsx
+++ b/src/frontend/components/LabelPage/LabelForm.jsx
@@ -16,7 +16,7 @@ const colorReducer = (state, action) => {
   return action.value;
 };
 
-const LabelForm = ({ label, toggle, edit }) => {
+const LabelForm = ({ label, toggle }) => {
   const [title, setTitle] = useState(label ? label.title : '');
   const [description, setDescription] = useState(label ? label.description : '');
   const [color, dispatchColorAction] = useReducer(colorReducer,
@@ -26,6 +26,7 @@ const LabelForm = ({ label, toggle, edit }) => {
   const validTitle = !!title.length;
   const validColor = testHexColorString(color);
   const [submitDisable, setSubmitDisable] = useState(true);
+  const edit = Boolean(label);
 
   useEffect(() => {
     setSubmitDisable(submitDisable || !(validTitle && validColor));
@@ -185,10 +186,6 @@ LabelForm.propTypes = {
     color: PropTypes.string.isRequired,
   }),
   toggle: PropTypes.func.isRequired,
-  edit: PropTypes.bool,
-};
-LabelForm.defaultProps = {
-  edit: false,
 };
 
 const FlexColumnBox = `

--- a/src/frontend/components/LabelPage/LabelForm.jsx
+++ b/src/frontend/components/LabelPage/LabelForm.jsx
@@ -17,9 +17,10 @@ const colorReducer = (state, action) => {
 };
 
 const LabelForm = ({ label, toggle, edit }) => {
-  const [title, setTitle] = useState(label.title);
-  const [description, setDescription] = useState(label.description);
-  const [color, dispatchColorAction] = useReducer(colorReducer, label.color);
+  const [title, setTitle] = useState(label ? label.title : '');
+  const [description, setDescription] = useState(label ? label.description : '');
+  const [color, dispatchColorAction] = useReducer(colorReducer,
+    label ? label.color : getRandomColor());
   const [previewColor, setPreviewColor] = useState(color);
   const requestFetch = useLabelFetchDispatcher();
   const validTitle = !!title.length;
@@ -187,12 +188,6 @@ LabelForm.propTypes = {
   edit: PropTypes.bool,
 };
 LabelForm.defaultProps = {
-  label: {
-    id: null,
-    title: '',
-    description: '',
-    color: getRandomColor(),
-  },
   edit: false,
 };
 

--- a/src/frontend/components/LabelPage/LabelForm.jsx
+++ b/src/frontend/components/LabelPage/LabelForm.jsx
@@ -36,11 +36,12 @@ const LabelForm = (props) => {
     const body = { title, description, color };
     useFetch('/api/labels', 'POST', body)
       .then((res) => {
-        // TODO: 완성된 label 읽어와서 리스트에 넣기.
-        alert(res.message);
         if (res.message === 'create success') {
           requestFetch();
           props.toggle();
+        } else {
+          // TODO: 실패했을때 어케할지???
+          alert(res.message);
         }
       });
   }, [title, description, color]);

--- a/src/frontend/components/LabelPage/LabelForm.jsx
+++ b/src/frontend/components/LabelPage/LabelForm.jsx
@@ -1,5 +1,5 @@
 import React, {
-  useCallback, useEffect, useReducer, useState,
+  useCallback, useMemo, useEffect, useReducer, useState,
 } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
@@ -27,7 +27,9 @@ const LabelForm = (props) => {
     if (validColor) setPreviewColor(color);
   }, [color]);
 
-  const submitLabel = useCallback((e) => {
+  const randomizeColor = useCallback(() => dispatchColorAction({ randomize: true }), []);
+
+  const postLabel = useCallback((e) => {
     e.preventDefault();
     const body = { title, description, color };
     useFetch('/api/labels', 'POST', body)
@@ -50,12 +52,21 @@ const LabelForm = (props) => {
     dispatchColorAction({ value: `#${value.replaceAll('#', '')}`.slice(0, 7) });
   }, [dispatchColorAction]);
 
-  const randomizeColor = useCallback(() => dispatchColorAction({ randomize: true }), []);
+  const patchLabel = (e) => {
+    e.preventDefault(e);
+  };
+
+  const submitLabel = useMemo(() => (props.edit ? patchLabel : postLabel), [props.edit]);
+  const submitButtonText = useMemo(() => (props.edit ? 'Save changes' : 'Create label'), [props.edit]);
+  const DeleteButton = useMemo(() => (props.edit ? (
+    <TextButton>Delete</TextButton>
+  ) : null));
 
   return (
-    <NewLabelForm onSubmit={submitLabel}>
+    <Box onSubmit={submitLabel}>
       <LabelPreviewWrapper>
         <LabelPreview title={title} description={description} color={previewColor} />
+        {DeleteButton}
       </LabelPreviewWrapper>
       <FormWrapper>
         <FormBody>
@@ -115,13 +126,13 @@ const LabelForm = (props) => {
           />
           <Button
             type='confirm'
-            text='Create label'
+            text={submitButtonText}
             valid={validtitle && validColor}
             htmlType='submit'
           />
         </ButtonWrapper>
       </FormWrapper>
-    </NewLabelForm>
+    </Box>
   );
 };
 
@@ -130,11 +141,13 @@ LabelForm.propTypes = {
   description: PropTypes.string,
   color: PropTypes.string,
   toggle: PropTypes.func.isRequired,
+  edit: PropTypes.bool,
 };
 LabelForm.defaultProps = {
   title: '',
   description: '',
   color: getRandomColor(),
+  edit: false,
 };
 
 const FlexColumnBox = `
@@ -149,6 +162,7 @@ const FlexRowBox = `
 
 const LabelPreviewWrapper = styled.div`
   ${FlexRowBox}
+  justify-content: space-between;
   margin-bottom: 1em;
 `;
 
@@ -187,6 +201,12 @@ const FormLabel = styled.label`
   }
 `;
 
+const TextButton = styled.button`
+  all: unset;
+  font-size: 12px;
+  color: ${(props) => props.theme.secondaryTextColor};
+`;
+
 const FormInput = styled.input`
   width: 100%;
   height: 31px;
@@ -203,13 +223,8 @@ const ColorPickerButton = styled.button`
   margin-right: 0.5em;
 `;
 
-const NewLabelForm = styled.form`
+const Box = styled.form`
   ${FlexColumnBox}
-  padding: 1em;
-  background-color: ${(props) => props.theme.menuBarBgColor};
-  border: 1px ${(props) => props.theme.menuBarBorderColor};
-  border-radius: 6px;
-  margin-bottom: 1rem;
 `;
 
 export default LabelForm;

--- a/src/frontend/components/LabelPage/LabelForm.jsx
+++ b/src/frontend/components/LabelPage/LabelForm.jsx
@@ -15,11 +15,6 @@ const colorReducer = (state, action) => {
   return action.value;
 };
 
-const changeColorInput = (event, dispatch) => {
-  const { value } = event.target;
-  dispatch({ value: `#${value.replaceAll('#', '')}`.slice(0, 7) });
-};
-
 const LabelForm = (props) => {
   const [title, setTitle] = useState(props.title);
   const [description, setDescription] = useState(props.description);
@@ -43,6 +38,20 @@ const LabelForm = (props) => {
       });
   }, [title, description, color]);
 
+  const changeTitleInput = useCallback(({ target: { value } }) => {
+    setTitle(value);
+  }, [setTitle]);
+
+  const changeDescriptionInput = useCallback(({ target: { value } }) => {
+    setDescription(value);
+  }, [setDescription]);
+
+  const changeColorInput = useCallback(({ target: { value } }) => {
+    dispatchColorAction({ value: `#${value.replaceAll('#', '')}`.slice(0, 7) });
+  }, [dispatchColorAction]);
+
+  const randomizeColor = useCallback(() => dispatchColorAction({ randomize: true }), []);
+
   return (
     <NewLabelForm onSubmit={submitLabel}>
       <LabelPreviewWrapper>
@@ -59,7 +68,7 @@ const LabelForm = (props) => {
             name='title'
             placeholder='Label name'
             value={title}
-            onChange={({ target: { value } }) => setTitle(value)}
+            onChange={changeTitleInput}
             maxLength={50}
             />}
           </FormLabel>
@@ -70,7 +79,7 @@ const LabelForm = (props) => {
             name='description'
             placeholder='Description (optional)'
             value={description}
-            onChange={({ target: { value } }) => setDescription(value)}
+            onChange={changeDescriptionInput}
             maxLength={100}
             />}
           </FormLabel>
@@ -81,7 +90,7 @@ const LabelForm = (props) => {
               type='button'
               title='Get a new color'
               color={previewColor}
-              onClick={() => dispatchColorAction({ randomize: true })}>
+              onClick={randomizeColor}>
                 <RefreshIcon />
               </ColorPickerButton>
               <FormInput
@@ -91,7 +100,7 @@ const LabelForm = (props) => {
               name='color'
               title='Hex colors should only contain number and letters from a-f'
               value={color}
-              onChange={(e) => changeColorInput(e, dispatchColorAction)}
+              onChange={changeColorInput}
               maxLength={8}
               />
             </ColorInputWrapper>}

--- a/src/frontend/components/LabelPage/LabelForm.jsx
+++ b/src/frontend/components/LabelPage/LabelForm.jsx
@@ -24,11 +24,11 @@ const changeColorInput = (event, dispatch) => {
 };
 
 const LabelForm = (props) => {
-  const [name, setName] = useState(props.name);
+  const [title, setTitle] = useState(props.title);
   const [description, setDescription] = useState(props.description);
   const [color, dispatchColorAction] = useReducer(colorReducer, props.color);
   const [previewColor, setPreviewColor] = useState(color);
-  const validName = !!name.length;
+  const validtitle = !!title.length;
   const validColor = testHexColorString(color);
 
   useEffect(() => {
@@ -38,19 +38,20 @@ const LabelForm = (props) => {
   return (
     <NewLabelForm onSubmit={submitLabel}>
       <LabelPreviewWrapper>
-        <LabelPreview name={name} description={description} color={previewColor} />
+        <LabelPreview title={title} description={description} color={previewColor} />
       </LabelPreviewWrapper>
       <FormWrapper>
         <FormBody>
-          <FormLabel for='input-name'>
+          <FormLabel for='input-title'>
             Label name
             {<FormInput
             required
             autoFocus
-            id='input-name'
+            id='input-title'
+            name='title'
             placeholder='Label name'
-            value={name}
-            onChange={({ target: { value } }) => setName(value)}
+            value={title}
+            onChange={({ target: { value } }) => setTitle(value)}
             maxLength={50}
             />}
           </FormLabel>
@@ -58,6 +59,7 @@ const LabelForm = (props) => {
             Description
             {<FormInput
             id='input-description'
+            name='description'
             placeholder='Description (optional)'
             value={description}
             onChange={({ target: { value } }) => setDescription(value)}
@@ -78,6 +80,7 @@ const LabelForm = (props) => {
               required
               invalid={!validColor}
               id='input-color'
+              name='color'
               title='Hex colors should only contain number and letters from a-f'
               value={color}
               onChange={(e) => changeColorInput(e, dispatchColorAction)}
@@ -96,7 +99,7 @@ const LabelForm = (props) => {
           <Button
             type='confirm'
             text='Create label'
-            valid={validName && validColor}
+            valid={validtitle && validColor}
             htmlType='submit'
           />
         </ButtonWrapper>
@@ -106,13 +109,13 @@ const LabelForm = (props) => {
 };
 
 LabelForm.propTypes = {
-  name: PropTypes.string,
+  title: PropTypes.string,
   description: PropTypes.string,
   color: PropTypes.string,
   toggle: PropTypes.func.isRequired,
 };
 LabelForm.defaultProps = {
-  name: '',
+  title: '',
   description: '',
   color: getRandomColor(),
 };

--- a/src/frontend/components/LabelPage/LabelForm.jsx
+++ b/src/frontend/components/LabelPage/LabelForm.jsx
@@ -16,10 +16,10 @@ const colorReducer = (state, action) => {
   return action.value;
 };
 
-const LabelForm = (props) => {
-  const [title, setTitle] = useState(props.title);
-  const [description, setDescription] = useState(props.description);
-  const [color, dispatchColorAction] = useReducer(colorReducer, props.color);
+const LabelForm = ({ label, toggle, edit }) => {
+  const [title, setTitle] = useState(label.title);
+  const [description, setDescription] = useState(label.description);
+  const [color, dispatchColorAction] = useReducer(colorReducer, label.color);
   const [previewColor, setPreviewColor] = useState(color);
   const requestFetch = useLabelFetchDispatcher();
   const validTitle = !!title.length;
@@ -57,7 +57,7 @@ const LabelForm = (props) => {
         setSubmitDisable(!(validTitle && validColor));
         if (res.message === 'create success') {
           requestFetch();
-          props.toggle();
+          toggle();
         } else {
           // TODO: 실패했을때 어케할지???
           alert(res.message);
@@ -69,12 +69,12 @@ const LabelForm = (props) => {
     e.preventDefault(e);
     setSubmitDisable(true);
     const body = { title, description, color };
-    useFetch(`/api/labels/${props.id}`, 'PATCH', body)
+    useFetch(`/api/labels/${label.id}`, 'PATCH', body)
       .then(() => {
         setSubmitDisable(!(validTitle && validColor));
         // TODO: 성공/실패 여부에 따라 어떻게 행동해야할지??
         requestFetch();
-        props.toggle();
+        toggle();
       });
   }, [title, description, color]);
 
@@ -82,23 +82,23 @@ const LabelForm = (props) => {
     e.preventDefault(e);
     const areyousure = window.confirm('Are you sure? Deleting a label will remove it from all issues and pull requests.');
     if (areyousure) {
-      useFetch(`/api/labels/${props.id}`, 'DELETE')
+      useFetch(`/api/labels/${label.id}`, 'DELETE')
         .then((res) => {
           if (res.message === 'delete success') requestFetch();
           else {
           // TODO: 삭제 실패 시 어떻게함??
             alert(res.message);
-            props.toggle();
+            toggle();
           }
         });
     }
   }, []);
 
-  const submitLabel = useMemo(() => (props.edit
+  const submitLabel = useMemo(() => (edit
     ? patchLabel : postLabel),
   [title, description, color]);
-  const submitButtonText = useMemo(() => (props.edit ? 'Save changes' : 'Create label'), []);
-  const DeleteButton = useMemo(() => (props.edit ? (
+  const submitButtonText = useMemo(() => (edit ? 'Save changes' : 'Create label'), []);
+  const DeleteButton = useMemo(() => (edit ? (
     <TextButton type='button' onClick={deleteLabel}>Delete</TextButton>
   ) : null), []);
 
@@ -161,7 +161,7 @@ const LabelForm = (props) => {
           <Button
             type='cancel'
             text='Cancel'
-            onClick={props.toggle}
+            onClick={toggle}
             htmlType='button'
           />
           <Button
@@ -177,17 +177,22 @@ const LabelForm = (props) => {
 };
 
 LabelForm.propTypes = {
-  id: PropTypes.number,
-  title: PropTypes.string,
-  description: PropTypes.string,
-  color: PropTypes.string,
+  label: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    title: PropTypes.string.isRequired,
+    description: PropTypes.string,
+    color: PropTypes.string.isRequired,
+  }),
   toggle: PropTypes.func.isRequired,
   edit: PropTypes.bool,
 };
 LabelForm.defaultProps = {
-  title: '',
-  description: '',
-  color: getRandomColor(),
+  label: {
+    id: null,
+    title: '',
+    description: '',
+    color: getRandomColor(),
+  },
   edit: false,
 };
 

--- a/src/frontend/components/LabelPage/LabelForm.jsx
+++ b/src/frontend/components/LabelPage/LabelForm.jsx
@@ -57,7 +57,7 @@ const LabelForm = (props) => {
     dispatchColorAction({ value: `#${value.replaceAll('#', '')}`.slice(0, 7) });
   }, [dispatchColorAction]);
 
-  const patchLabel = (e) => {
+  const patchLabel = useCallback((e) => {
     e.preventDefault(e);
     const body = { title, description, color };
     useFetch(`/api/labels/${props.id}`, 'PATCH', body)
@@ -66,9 +66,9 @@ const LabelForm = (props) => {
         requestFetch();
         props.toggle();
       });
-  };
+  }, [title, description, color]);
 
-  const deleteLabel = (e) => {
+  const deleteLabel = useCallback((e) => {
     e.preventDefault(e);
     const areyousure = window.confirm('Are you sure? Deleting a label will remove it from all issues and pull requests.');
     if (areyousure) {
@@ -82,11 +82,11 @@ const LabelForm = (props) => {
           }
         });
     }
-  };
+  }, []);
 
   const submitLabel = useMemo(() => (props.edit
     ? patchLabel : postLabel),
-  [props.edit, title, description, color]);
+  [title, description, color]);
   const submitButtonText = useMemo(() => (props.edit ? 'Save changes' : 'Create label'), []);
   const DeleteButton = useMemo(() => (props.edit ? (
     <TextButton type='button' onClick={deleteLabel}>Delete</TextButton>

--- a/src/frontend/components/LabelPage/LabelForm.jsx
+++ b/src/frontend/components/LabelPage/LabelForm.jsx
@@ -1,5 +1,5 @@
 import React, {
-  useEffect, useReducer, useState,
+  useCallback, useEffect, useReducer, useState,
 } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
@@ -7,11 +7,8 @@ import styled from 'styled-components';
 import Button from '@Components/Common/Button';
 import RefreshIcon from '@Images/refresh.svg';
 import { getRandomColor, testHexColorString } from '@Util/hexColor.js';
+import useFetch from '@Util/useFetch.js';
 import LabelPreview from './LabelPreview.jsx';
-
-const submitLabel = (e) => {
-  e.preventDefault();
-};
 
 const colorReducer = (state, action) => {
   if (action.randomize) return getRandomColor();
@@ -34,6 +31,17 @@ const LabelForm = (props) => {
   useEffect(() => {
     if (validColor) setPreviewColor(color);
   }, [color]);
+
+  const submitLabel = useCallback((e) => {
+    e.preventDefault();
+    const body = { title, description, color };
+    useFetch('/api/labels', 'POST', body)
+      .then((res) => {
+        // TODO: 완성된 label 읽어와서 리스트에 넣기.
+        alert(res.message);
+        if (res.message === 'create success') props.toggle();
+      });
+  }, [title, description, color]);
 
   return (
     <NewLabelForm onSubmit={submitLabel}>

--- a/src/frontend/components/LabelPage/LabelList.jsx
+++ b/src/frontend/components/LabelPage/LabelList.jsx
@@ -1,0 +1,60 @@
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import LabelListItem from './LabelListItem.jsx';
+
+const LabelList = ({ labels, count }) => {
+  const LabelListItems = useMemo(() => labels.map((label) => (
+    <LabelListItem key={`label-${label.id}`} label={label} />
+  )), [labels]);
+
+  return (
+    <Box>
+      <ListHeader>
+        <LabelCount>{count} label{count > 1 ? 's' : ''}</LabelCount>
+      </ListHeader>
+      {LabelListItems}
+    </Box>
+  );
+};
+
+LabelList.propTypes = {
+  labels: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    title: PropTypes.string.isRequired,
+    description: PropTypes.string,
+    color: PropTypes.string.isRequired,
+  })).isRequired,
+  count: PropTypes.number.isRequired,
+};
+LabelList.defaultProps = {
+  labels: [],
+  count: 0,
+};
+
+const LabelCount = styled.h3`
+  all: unset;
+  font-size: 14px;
+  font-weight: 600;
+`;
+
+const ListHeader = styled.div`
+  padding: 16px;
+  margin: -1px;
+  background-color: ${(props) => (props.theme.menuBarBgColor)};
+  border: 1px solid ${(props) => (props.theme.inputBorderColor)};
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+`;
+
+const Box = styled.div`
+  border: 1px solid ${(props) => (props.theme.inputBorderColor)};
+  border-radius: 6px;
+  
+  & > *:last-child {
+    border-bottom-left-radius: 6px;
+    border-bottom-right-radius: 6px;
+  }
+`;
+
+export default LabelList;

--- a/src/frontend/components/LabelPage/LabelListItem.jsx
+++ b/src/frontend/components/LabelPage/LabelListItem.jsx
@@ -13,6 +13,7 @@ const LabelListItem = ({ label }) => {
     <ItemWrapper>
       {showEditForm ? (
       <LabelForm
+      id={label.id}
       name={label.title} // TODO: 11-11자 PR들 다 merge되면 제거
       title={label.title}
       description={label.description}

--- a/src/frontend/components/LabelPage/LabelListItem.jsx
+++ b/src/frontend/components/LabelPage/LabelListItem.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import LabelPreview from './LabelPreview.jsx';
+
+const LabelListItem = ({ label }) => {
+  console.log(label);
+
+  return (
+    <Box>
+      <PreviewArea>
+        <LabelPreview
+        name={label.title} // TODO: 11-11자 PR들 다 merge되면 제거
+        title={label.title}
+        description={label.description}
+        color={label.color}
+        />
+      </PreviewArea>
+      <DescriptionArea>
+        {label.description}
+      </DescriptionArea>
+      <ActionArea>
+        <TextButton>Edit</TextButton>
+        <TextButton>Delete</TextButton>
+      </ActionArea>
+    </Box>
+  );
+};
+
+LabelListItem.propTypes = {
+  label: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    title: PropTypes.string.isRequired,
+    description: PropTypes.string,
+    color: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+const PreviewArea = styled.div`
+  display: flex;
+  width: 25%;
+`;
+
+const DescriptionArea = styled.div`
+  display: flex;
+  flex-grow: 1;
+  font-size: 12px;
+  color: ${(props) => props.theme.secondaryTextColor};
+`;
+
+const ActionArea = styled.div`
+  display: flex;
+  font-size: 12px;
+  color: ${(props) => props.theme.secondaryTextColor};
+`;
+
+const TextButton = styled.button`
+  all: unset;
+  margin-left: 1em;
+`;
+
+const Box = styled.div`
+  display: flex;
+  flex-direction: row;
+
+  padding: 16px;
+  border-top: 1px solid ${(props) => (props.theme.inputBorderColor)};
+`;
+
+export default LabelListItem;

--- a/src/frontend/components/LabelPage/LabelListItem.jsx
+++ b/src/frontend/components/LabelPage/LabelListItem.jsx
@@ -1,4 +1,4 @@
-import React, { useReducer } from 'react';
+import React, { useReducer, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import useFetch from '@Util/useFetch.js';
@@ -9,14 +9,17 @@ import { useLabelFetchDispatcher } from './LabelFetchDispatcher.jsx';
 const editFormReducer = (state) => !state;
 
 const LabelListItem = ({ label }) => {
+  const [submitDisable, setSubmitDisable] = useState(false);
   const [showEditForm, toggleEditForm] = useReducer(editFormReducer, false);
   const requestFetch = useLabelFetchDispatcher();
 
   const deleteLabel = (e) => {
     const areyousure = window.confirm('Are you sure? Deleting a label will remove it from all issues and pull requests.');
     if (areyousure) {
+      setSubmitDisable(true);
       useFetch(`/api/labels/${label.id}`, 'DELETE')
         .then((res) => {
+          setSubmitDisable(false);
           if (res.message === 'delete success') requestFetch();
           else {
           // TODO: 삭제 실패 시 어떻게함??
@@ -30,11 +33,7 @@ const LabelListItem = ({ label }) => {
     <ItemWrapper>
       {showEditForm ? (
       <LabelForm
-      id={label.id}
-      name={label.title} // TODO: 11-11자 PR들 다 merge되면 제거
-      title={label.title}
-      description={label.description}
-      color={label.color}
+      label={label}
       toggle={toggleEditForm}
       edit
       />
@@ -42,7 +41,6 @@ const LabelListItem = ({ label }) => {
       <FlexRowBox>
         <PreviewArea>
           <LabelPreview
-          name={label.title} // TODO: 11-11자 PR들 다 merge되면 제거
           title={label.title}
           description={label.description}
           color={label.color}
@@ -53,7 +51,7 @@ const LabelListItem = ({ label }) => {
         </DescriptionArea>
         <ActionArea>
           <TextButton onClick={toggleEditForm}>Edit</TextButton>
-          <TextButton onClick={deleteLabel}>Delete</TextButton>
+          <TextButton disabled={submitDisable} onClick={deleteLabel}>Delete</TextButton>
         </ActionArea>
       </FlexRowBox>
       )}

--- a/src/frontend/components/LabelPage/LabelListItem.jsx
+++ b/src/frontend/components/LabelPage/LabelListItem.jsx
@@ -35,7 +35,6 @@ const LabelListItem = ({ label }) => {
       <LabelForm
       label={label}
       toggle={toggleEditForm}
-      edit
       />
       ) : (
       <FlexRowBox>

--- a/src/frontend/components/LabelPage/LabelListItem.jsx
+++ b/src/frontend/components/LabelPage/LabelListItem.jsx
@@ -1,13 +1,30 @@
 import React, { useReducer } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import useFetch from '@Util/useFetch.js';
 import LabelPreview from './LabelPreview.jsx';
 import LabelForm from './LabelForm.jsx';
+import { useLabelFetchDispatcher } from './LabelFetchDispatcher.jsx';
 
 const editFormReducer = (state) => !state;
 
 const LabelListItem = ({ label }) => {
   const [showEditForm, toggleEditForm] = useReducer(editFormReducer, false);
+  const requestFetch = useLabelFetchDispatcher();
+
+  const deleteLabel = (e) => {
+    const areyousure = window.confirm('Are you sure? Deleting a label will remove it from all issues and pull requests.');
+    if (areyousure) {
+      useFetch(`/api/labels/${label.id}`, 'DELETE')
+        .then((res) => {
+          if (res.message === 'delete success') requestFetch();
+          else {
+          // TODO: 삭제 실패 시 어떻게함??
+            alert(res.message);
+          }
+        });
+    }
+  };
 
   return (
     <ItemWrapper>
@@ -36,7 +53,7 @@ const LabelListItem = ({ label }) => {
         </DescriptionArea>
         <ActionArea>
           <TextButton onClick={toggleEditForm}>Edit</TextButton>
-          <TextButton>Delete</TextButton>
+          <TextButton onClick={deleteLabel}>Delete</TextButton>
         </ActionArea>
       </FlexRowBox>
       )}

--- a/src/frontend/components/LabelPage/LabelListItem.jsx
+++ b/src/frontend/components/LabelPage/LabelListItem.jsx
@@ -1,29 +1,45 @@
-import React from 'react';
+import React, { useReducer } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import LabelPreview from './LabelPreview.jsx';
+import LabelForm from './LabelForm.jsx';
+
+const editFormReducer = (state) => !state;
 
 const LabelListItem = ({ label }) => {
-  console.log(label);
+  const [showEditForm, toggleEditForm] = useReducer(editFormReducer, false);
 
   return (
-    <Box>
-      <PreviewArea>
-        <LabelPreview
-        name={label.title} // TODO: 11-11자 PR들 다 merge되면 제거
-        title={label.title}
-        description={label.description}
-        color={label.color}
-        />
-      </PreviewArea>
-      <DescriptionArea>
-        {label.description}
-      </DescriptionArea>
-      <ActionArea>
-        <TextButton>Edit</TextButton>
-        <TextButton>Delete</TextButton>
-      </ActionArea>
-    </Box>
+    <ItemWrapper>
+      {showEditForm ? (
+      <LabelForm
+      name={label.title} // TODO: 11-11자 PR들 다 merge되면 제거
+      title={label.title}
+      description={label.description}
+      color={label.color}
+      toggle={toggleEditForm}
+      edit
+      />
+      ) : (
+      <FlexRowBox>
+        <PreviewArea>
+          <LabelPreview
+          name={label.title} // TODO: 11-11자 PR들 다 merge되면 제거
+          title={label.title}
+          description={label.description}
+          color={label.color}
+          />
+        </PreviewArea>
+        <DescriptionArea>
+          {label.description}
+        </DescriptionArea>
+        <ActionArea>
+          <TextButton onClick={toggleEditForm}>Edit</TextButton>
+          <TextButton>Delete</TextButton>
+        </ActionArea>
+      </FlexRowBox>
+      )}
+    </ItemWrapper>
   );
 };
 
@@ -59,10 +75,12 @@ const TextButton = styled.button`
   margin-left: 1em;
 `;
 
-const Box = styled.div`
+const FlexRowBox = styled.div`
   display: flex;
   flex-direction: row;
+`;
 
+const ItemWrapper = styled.div`
   padding: 16px;
   border-top: 1px solid ${(props) => (props.theme.inputBorderColor)};
 `;

--- a/src/frontend/components/LabelPage/LabelPage.jsx
+++ b/src/frontend/components/LabelPage/LabelPage.jsx
@@ -8,6 +8,7 @@ import Button from '@Components/Common/Button';
 import useFetch from '@Util/useFetch.js';
 import LabelForm from './LabelForm.jsx';
 import LabelList from './LabelList.jsx';
+import LabelFetchDispatcher from './LabelFetchDispatcher.jsx';
 
 const labelFormReducer = (state) => !state;
 
@@ -32,37 +33,41 @@ const LabelPage = () => {
     }
   }, [loading]);
 
+  const dispatchFetch = () => setLoading(true);
+
   return (
-    <Container>
-      <ActionNavBar>
-        <LinkButtonBox>
-          <LinkButton
-            SvgIcon={labelIcon}
-            title={'Labels'}
-            isLeftRounded={true}
-            link={'/labels'}
-            active
+    <LabelFetchDispatcher.Provider value={dispatchFetch}>
+      <Container>
+        <ActionNavBar>
+          <LinkButtonBox>
+            <LinkButton
+              SvgIcon={labelIcon}
+              title={'Labels'}
+              isLeftRounded={true}
+              link={'/labels'}
+              active
+            />
+            <LinkButton
+              SvgIcon={milestoneIcon}
+              title={'Milestones'}
+              isLeftRounded={false}
+              link={'/milestones'}
+            />
+          </LinkButtonBox>
+          <Button
+            type='confirm'
+            text='New label'
+            onClick={toggleLabelForm}
           />
-          <LinkButton
-            SvgIcon={milestoneIcon}
-            title={'Milestones'}
-            isLeftRounded={false}
-            link={'/milestones'}
-          />
-        </LinkButtonBox>
-        <Button
-          type='confirm'
-          text='New label'
-          onClick={toggleLabelForm}
-        />
-      </ActionNavBar>
-      {showLabelForm && (
-      <PostLabelArea>
-        <LabelForm toggle={toggleLabelForm} />
-      </PostLabelArea>
-      )}
-      <LabelList labels={labels} count={labels.length} />
-    </Container>
+        </ActionNavBar>
+        {showLabelForm && (
+        <PostLabelArea>
+          <LabelForm toggle={toggleLabelForm} />
+        </PostLabelArea>
+        )}
+        <LabelList labels={labels} count={labels.length} />
+      </Container>
+    </LabelFetchDispatcher.Provider>
   );
 };
 

--- a/src/frontend/components/LabelPage/LabelPage.jsx
+++ b/src/frontend/components/LabelPage/LabelPage.jsx
@@ -56,7 +56,11 @@ const LabelPage = () => {
           onClick={toggleLabelForm}
         />
       </ActionNavBar>
-      {showLabelForm && <LabelForm toggle={toggleLabelForm} />}
+      {showLabelForm && (
+      <PostLabelArea>
+        <LabelForm toggle={toggleLabelForm} />
+      </PostLabelArea>
+      )}
       <LabelList labels={labels} count={labels.length} />
     </Container>
   );
@@ -78,6 +82,14 @@ const Container = styled.div`
   min-width: 600px;
   max-width: 1200px;
   margin: auto;
+`;
+
+const PostLabelArea = styled.div`
+  padding: 1em;
+  background-color: ${(props) => (props.theme.menuBarBgColor)};
+  border: 1px ${(props) => props.theme.menuBarBorderColor};
+  border-radius: 6px;
+  margin-bottom: 1rem;
 `;
 
 const ActionNavBar = styled.nav`

--- a/src/frontend/components/LabelPage/LabelPage.jsx
+++ b/src/frontend/components/LabelPage/LabelPage.jsx
@@ -1,16 +1,18 @@
 import LinkButton from '@Components/Common/LinkButton';
-import React, { useReducer } from 'react';
+import React, { useEffect, useReducer, useState } from 'react';
 import styled from 'styled-components';
 
 import labelIcon from '@Images/comment.svg';
 import milestoneIcon from '@Images/milestone.svg';
 import Button from '@Components/Common/Button';
 import LabelForm from './LabelForm.jsx';
+import LabelList from './LabelList.jsx';
 
 const labelFormReducer = (state) => !state;
 
 const LabelPage = () => {
   const [showLabelForm, toggleLabelForm] = useReducer(labelFormReducer, false);
+  const [labels, setLabels] = useState([]);
 
   return (
     <Container>
@@ -37,6 +39,7 @@ const LabelPage = () => {
         />
       </ActionNavBar>
       {showLabelForm && <LabelForm toggle={toggleLabelForm} />}
+      <LabelList labels={labels} count={labels.length} />
     </Container>
   );
 };

--- a/src/frontend/components/LabelPage/LabelPage.jsx
+++ b/src/frontend/components/LabelPage/LabelPage.jsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import labelIcon from '@Images/comment.svg';
 import milestoneIcon from '@Images/milestone.svg';
 import Button from '@Components/Common/Button';
+import useFetch from '@Util/useFetch.js';
 import LabelForm from './LabelForm.jsx';
 import LabelList from './LabelList.jsx';
 
@@ -12,7 +13,24 @@ const labelFormReducer = (state) => !state;
 
 const LabelPage = () => {
   const [showLabelForm, toggleLabelForm] = useReducer(labelFormReducer, false);
+  const [loading, setLoading] = useState(true);
   const [labels, setLabels] = useState([]);
+
+  useEffect(() => {
+    if (loading) {
+      useFetch('/api/labels')
+        .then((res) => {
+          if (res.message) {
+            // TODO: error control
+            return;
+          }
+          setLabels(res);
+        })
+        .then(() => {
+          setLoading(false);
+        });
+    }
+  }, [loading]);
 
   return (
     <Container>

--- a/src/frontend/components/LabelPage/LabelPreview.jsx
+++ b/src/frontend/components/LabelPage/LabelPreview.jsx
@@ -23,7 +23,9 @@ LabelPreview.defaultProps = {
 };
 
 const LabelDiv = styled.div`
-  display: inline-block;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
   font-size: 12px;
   font-weight: 500;
   padding: 0 1em;

--- a/src/frontend/components/LabelPage/LabelPreview.jsx
+++ b/src/frontend/components/LabelPage/LabelPreview.jsx
@@ -22,7 +22,10 @@ LabelPreview.defaultProps = {
   title: 'Label preview',
 };
 
-const LabelDiv = styled.span`
+const LabelDiv = styled.div`
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 500;
   padding: 0 1em;
   border-radius: 2em;
   background-color: ${(props) => props.color}

--- a/src/frontend/components/LabelPage/LabelPreview.jsx
+++ b/src/frontend/components/LabelPage/LabelPreview.jsx
@@ -3,23 +3,23 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 const LabelPreview = (props) => {
-  const hint = props.description || props.name;
-  const name = props.name || 'Label preview';
+  const hint = props.description || props.title;
+  const title = props.title || 'Label preview';
 
   return (
     <LabelDiv title={hint} color={props.color}>
-      {name}
+      {title}
     </LabelDiv>
   );
 };
 
 LabelPreview.propTypes = {
-  name: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
   description: PropTypes.string,
   color: PropTypes.string.isRequired,
 };
 LabelPreview.defaultProps = {
-  name: 'Label preview',
+  title: 'Label preview',
 };
 
 const LabelDiv = styled.span`

--- a/src/frontend/components/LabelPage/LabelPreview.jsx
+++ b/src/frontend/components/LabelPage/LabelPreview.jsx
@@ -2,13 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-const LabelPreview = (props) => {
-  const hint = props.description || props.title;
-  const title = props.title || 'Label preview';
+const LabelPreview = ({ title, description, color }) => {
+  const hint = description || title;
+  const name = title || 'Label preview';
 
   return (
-    <LabelDiv title={hint} color={props.color}>
-      {title}
+    <LabelDiv title={hint} color={color}>
+      {name}
     </LabelDiv>
   );
 };

--- a/src/frontend/theme/index.js
+++ b/src/frontend/theme/index.js
@@ -51,6 +51,7 @@ export const theme = {
   subButtonColor: '#eee',
   whiteColor: '#ffffff',
   commonTextColor: '#222222',
+  secondaryTextColor: '#586069',
   shadowColor: '#CCCCCC',
 
   userNameColor: '#333333',


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/48747221/98787982-8bb16680-2443-11eb-961e-a8b912b88fd1.png)

GET POST PATCH DELETE 모두 실시간 대응합니다~

## 컴포넌트 구조 (변경사항만 기재)
### LabelPage.jsx
엔트리 페이지. BE에 GET /labels 요청을 보내고 LabelList에 라벨 목록을 전달한다. GET /labels 요청을 자주 다시 보내야하므로 이 명령을 dispatch할 수 있는 함수를 context API로 하위 컴포넌트들에서 쉽게 접근가능하게 했다. context API 부분은 아래 LabelFetchDispatcher가 담당하고있다.

### LabelFetchDispatcher.jsx
LabelPage의 `loading` state를 LabelPage 내부의 여러 컴포넌트들이 조작할 필요가 있었으므로 `setLoading()`을 context API로 제공하고자 했음. 
맨처음엔 LabelPage에 있었는데 순환 참조가 발생해서 별도 파일으로 분리.

### LabelForm.jsx
label prop을 전달받을 경우 Edit form을 렌더링하고 전달받지 못한 경우 Post form을 렌더링한다.

### LabelList.jsx
Array.prototype.map을 이용해서 여러개의 LabelListItem을 렌더링하는 부모 컴포넌트.

### LabelListItem.jsx
라벨 리스트의 각 child component. 기존에 LabelForm에서 사용했던 LabelPreview를 재활용할수있었다. Edit 기능도 기존 LabelForm을 그대로 사용할 수 있었다.

closes #55, closes #56, closes #57, closes #59, closes #142