### PR TITLE
BE Milestone API 추가 마일스톤 생성 기능, 수정 기능 구현

### DIFF
--- a/src/backend/controllers/milestones.js
+++ b/src/backend/controllers/milestones.js
@@ -30,6 +30,39 @@ export const getAllMilestones = async (req, res) => {
   }
 };
 
+export const getMiletone = async (req, res) => {
+  try {
+    const milestones = await db.Milestone.findAll({
+      attributes: [
+        'id', 'title', 'dueDate', 'isOpened', 'description',
+        [db.Sequelize.literal('(SELECT SUM(`issues`.`isOpened` = 0))'), 'closed'],
+        [db.Sequelize.literal('(SELECT SUM(`issues`.`isOpened`))'), 'opened'],
+        [db.Sequelize.literal('(SELECT TRUNCATE((SUM(`issues`.`isOpened` = 0) / COUNT(`issues`.`id`)) * 100, 0))'), 'progress'],
+      ],
+      include: {
+        model: db.Issue,
+        as: 'issues',
+        attributes: [],
+      },
+      group: [
+        'Milestone.id',
+      ],
+      where: {
+        id: req.params.id,
+      },
+    });
+    res.status(200).json({
+      message: 'success',
+      milestones,
+    });
+  } catch (error) {
+    res.status(500).json({
+      message: error,
+      milestones: [],
+    });
+  }
+};
+
 export const createMilestone = async (req, res) => {
   try {
     const Milestone = {

--- a/src/backend/controllers/milestones.js
+++ b/src/backend/controllers/milestones.js
@@ -34,8 +34,8 @@ export const createMilestone = async (req, res) => {
   try {
     const Milestone = {
       title: req.body.title,
-      dueDate: req.body.dueDate === '' ? null : new Date(req.body.dueDate),
-      description: req.body.description === '' ? null : req.body.description,
+      dueDate: req.body.dueDate === null ? null : new Date(req.body.dueDate),
+      description: req.body.description === null ? null : req.body.description,
       isOpened: true,
     };
 

--- a/src/backend/controllers/milestones.js
+++ b/src/backend/controllers/milestones.js
@@ -34,10 +34,11 @@ export const createMilestone = async (req, res) => {
   try {
     const Milestone = {
       title: req.body.title,
-      dueDate: new Date(req.body.dueDate),
-      description: req.body.description,
+      dueDate: req.body.dueDate === '' ? null : new Date(req.body.dueDate),
+      description: req.body.description === '' ? null : req.body.description,
       isOpened: true,
     };
+
     const milestone = await db.Milestone.create(Milestone);
 
     res.status(200).json({ id: milestone.get('id'), message: 'create success' });

--- a/src/backend/routes/milestones.js
+++ b/src/backend/routes/milestones.js
@@ -1,12 +1,13 @@
 import { Router } from 'express';
 import {
-  getAllMilestones, createMilestone, updateMilestone, removeMilestone,
+  getAllMilestones, createMilestone, updateMilestone, removeMilestone, getMiletone,
 } from '../controllers/milestones';
 
 const LabelRouter = Router();
 
 // 레이블 목록
 LabelRouter.get('/', getAllMilestones);
+LabelRouter.get('/:id', getMiletone);
 LabelRouter.post('/', createMilestone);
 LabelRouter.patch('/:id', updateMilestone);
 LabelRouter.delete('/:id', removeMilestone);

--- a/src/frontend/components/Milestone/Milestone.jsx
+++ b/src/frontend/components/Milestone/Milestone.jsx
@@ -4,9 +4,9 @@ import ProgressBar from '@Components/Milestone/ProgressBar';
 import { useHistory } from 'react-router';
 
 const Milestone = (props) => {
-  const {
-    closed,
-    opened,
+  let {
+    closed: closedCount,
+    opened: openedCount,
     description,
     dueDate,
     id,
@@ -15,13 +15,16 @@ const Milestone = (props) => {
     title,
   } = props.data;
 
+  progress = progress === null ? 0 : progress;
+  closedCount = closedCount === null ? 0 : closedCount;
+  openedCount = openedCount === null ? 0 : openedCount;
+
   const history = useHistory();
   const moveToEdit = useCallback(() => {
     history.push(`/milestones/edit/${id}`);
   }, [history]);
 
   const date = dueDate === null ? 'No due Date' : new Date(dueDate);
-
   return (
       <Main>
         <LeftArea>
@@ -33,8 +36,8 @@ const Milestone = (props) => {
           <ProgressBar progress={progress}></ProgressBar>
           <RowArea>
             <MarginLabel>{progress}% complete</MarginLabel>
-            <MarginLabel>{opened} open</MarginLabel>
-            <MarginLabel>{closed} closed</MarginLabel>
+            <MarginLabel>{openedCount} open</MarginLabel>
+            <MarginLabel>{closedCount} closed</MarginLabel>
           </RowArea>
           <RowArea>
             <MarginButton onClick={moveToEdit}>Edit</MarginButton>

--- a/src/frontend/components/Milestone/Milestone.jsx
+++ b/src/frontend/components/Milestone/Milestone.jsx
@@ -20,13 +20,13 @@ const Milestone = (props) => {
     history.push(`/milestones/edit/${id}`);
   }, [history]);
 
-  const date = new Date(dueDate);
+  const date = dueDate === null ? 'No due Date' : new Date(dueDate);
 
   return (
       <Main>
         <LeftArea>
           <label>{title}</label>
-          <label>Due by {date.getMonth()}, {date.getDate()}, {date.getFullYear()}</label>
+          {typeof (date) === 'string' ? date : <label>Due by {date.getMonth()}, {date.getDate()}, {date.getFullYear()}</label>}
           <label>{description}</label>
         </LeftArea>
         <RightArea>

--- a/src/frontend/components/Milestone/ProgressBar.jsx
+++ b/src/frontend/components/Milestone/ProgressBar.jsx
@@ -4,30 +4,30 @@ import styled from 'styled-components';
 const ProgressBar = (props) => {
   const { progress } = props;
 
-  const Green = styled.div`
-  width: ${progress}%;
-  height: 1rem;
-  padding: none;
-  margin: none;
-  border: none;
-  background-color: ${(props) => props.theme.buttonColor};
-`;
-  const Gray = styled.div`
-  width: ${100 - progress}%;
-  height: 1rem;
-  padding: none;
-  margin: none;
-  border: none;
-  background-color: ${(props) => props.theme.grayBorderColor};
-`;
-
   return (
     <Bar>
-      <Green></Green>
-      <Gray></Gray>
+      <Green progress={progress}></Green>
+      <Gray progress={progress}></Gray>
     </Bar>
   );
 };
+
+const Green = styled.div`
+width: ${(props) => props.progress}%;
+height: 1rem;
+padding: none;
+margin: none;
+border: none;
+background-color: ${(props) => props.theme.buttonColor};
+`;
+const Gray = styled.div`
+width: ${(props) => 100 - props.progress}%;
+height: 1rem;
+padding: none;
+margin: none;
+border: none;
+background-color: ${(props) => props.theme.grayBorderColor};
+`;
 
 const Bar = styled.div`
   display: flex;

--- a/src/frontend/components/MilestoneEdit/MilestoneEdit.jsx
+++ b/src/frontend/components/MilestoneEdit/MilestoneEdit.jsx
@@ -1,13 +1,17 @@
-import React, { useCallback } from 'react';
+import React, {
+  useCallback, useEffect, useReducer, useState,
+} from 'react';
 import styled from 'styled-components';
 import LabelIcon from '@Images/comment.svg';
 import MilestoneIconWhite from '@Images/milestoneWhite.svg';
 import Button from '@Common/Button';
 import { useHistory, useParams } from 'react-router';
+import useFetch from '@Util/useFetch';
 
 const MilestoneEdit = () => {
   const history = useHistory();
   const { id } = useParams();
+  const [loading, setLoading] = useState(false);
 
   const moveToLabels = useCallback(() => {
     history.push('/labels');
@@ -16,6 +20,37 @@ const MilestoneEdit = () => {
   const moveToMilestones = useCallback(() => {
     history.push('/milestones');
   }, [history]);
+
+  const inputReducer = (state, action) => {
+    switch (action.type) {
+      case 'title':
+        state.title = action.value;
+        break;
+      case 'dueDate':
+        state.dueDate = action.value;
+        break;
+      case 'description':
+        state.description = action.value;
+        break;
+      default:
+    }
+    return state;
+  };
+
+  const [inputValue, inputHandler] = useReducer(inputReducer, { title: null, dueDate: null, description: null });
+
+  useEffect(async () => {
+    if (!loading) {
+      const result = await useFetch(`/api/milestones/${id}`, 'GET');
+      const dateObj = new Date(result.milestones[0].dueDate);
+      const dueDate = `${dateObj.getFullYear()}-${dateObj.getMonth()}-${dateObj.getDate()}`;
+
+      inputHandler({ type: 'title', value: result.milestones[0].title });
+      inputHandler({ type: 'dueDate', value: dueDate.toString() });
+      inputHandler({ type: 'description', value: result.milestones[0].description });
+      setLoading(true);
+    }
+  }, [loading]);
 
   return (
       <Main>
@@ -28,11 +63,11 @@ const MilestoneEdit = () => {
             </MenuBox>
               <RowLine/>
               <h4>title</h4>
-              <TextInput type="text" name="title"></TextInput>
+              <TextInput type="text" name="title" value={inputValue.title} onChange={(e) => inputHandler({ type: 'title', value: e.target.value })}></TextInput>
               <h4>Due date (optional)</h4>
-              <DateInput type="date" name="dueDate"></DateInput>
+              <DateInput type="date" name="dueDate" value={inputValue.dueDate} onChange={(e) => inputHandler({ type: 'dueDate', value: e.target.value })}></DateInput>
               <h4>Description (optional)</h4>
-              <TextareaInput name="description"></TextareaInput>
+              <TextareaInput name="description" value={inputValue.description} onChange={(e) => inputHandler({ type: 'description', value: e.target.value })}></TextareaInput>
               <RowLine/>
               <ButtonArea>
                 <Button text="Cancel" type="cancel"/>

--- a/src/frontend/components/MilestoneEdit/MilestoneEdit.jsx
+++ b/src/frontend/components/MilestoneEdit/MilestoneEdit.jsx
@@ -3,12 +3,18 @@ import styled from 'styled-components';
 import LabelIcon from '@Images/comment.svg';
 import MilestoneIconWhite from '@Images/milestoneWhite.svg';
 import Button from '@Common/Button';
-import { useHistory } from 'react-router';
+import { useHistory, useParams } from 'react-router';
 
 const MilestoneEdit = () => {
   const history = useHistory();
+  const { id } = useParams();
+
   const moveToLabels = useCallback(() => {
     history.push('/labels');
+  }, [history]);
+
+  const moveToMilestones = useCallback(() => {
+    history.push('/milestones');
   }, [history]);
 
   return (
@@ -16,7 +22,9 @@ const MilestoneEdit = () => {
           <Content>
             <MenuBox>
               <LabelLinkButton onClick={moveToLabels}><LabelIcon></LabelIcon>Label</LabelLinkButton>
-              <MilestoneLinkButton><MilestoneIconWhite></MilestoneIconWhite>Milestone</MilestoneLinkButton>
+              <MilestoneLinkButton onClick={moveToMilestones}><MilestoneIconWhite></MilestoneIconWhite>
+                Milestone
+              </MilestoneLinkButton>
             </MenuBox>
               <RowLine/>
               <h4>title</h4>

--- a/src/frontend/components/MilestoneEdit/MilestoneEdit.jsx
+++ b/src/frontend/components/MilestoneEdit/MilestoneEdit.jsx
@@ -17,35 +17,29 @@ const MilestoneEdit = () => {
             <MenuBox>
               <LabelLinkButton onClick={moveToLabels}><LabelIcon></LabelIcon>Label</LabelLinkButton>
               <MilestoneLinkButton><MilestoneIconWhite></MilestoneIconWhite>Milestone</MilestoneLinkButton>
-             </MenuBox>
-            <hr width="100%" height="1"/>
-            <form action="/milestones" method="POST">
+            </MenuBox>
+              <RowLine/>
               <h4>title</h4>
               <TextInput type="text" name="title"></TextInput>
               <h4>Due date (optional)</h4>
               <DateInput type="date" name="dueDate"></DateInput>
               <h4>Description (optional)</h4>
-              <TextareaInput cols="60" rows="20" resize="none" name="description"></TextareaInput>
-              <hr width="100%" height="1"/>
+              <TextareaInput name="description"></TextareaInput>
+              <RowLine/>
               <ButtonArea>
-                <Button
-                text="Cancel"
-                type="cancel"
-                />
-                <Button
-                text="Close Milestone"
-                type="cancel"
-               />
-               <Button
-               text="Save Changes"
-               />
+                <Button text="Cancel" type="cancel"/>
+                <Button text="Close Milestone" type="cancel"/>
+                <Button text="Save Changes" />
               </ButtonArea>
-
-            </form>
           </Content>
       </Main>
   );
 };
+
+const RowLine = styled.hr`
+  width: 100%;
+  height: 1;
+`;
 
 const FlexColumnBox = `
   display: flex;
@@ -104,11 +98,12 @@ const MilestoneLinkButton = styled.button`
 `;
 
 const ButtonArea = styled.div`
-  width: 33%;
   display: flex;
   flex-flow: row;
-  right:1px;
-  justify-content: space-between;
+  justify-content: flex-end;
+  & > button{
+    margin-left: 1rem;
+  }
 `;
 
 const TextInput = styled.input`
@@ -141,6 +136,9 @@ const TextareaInput = styled.textarea`
 border: 1px solid ${(props) => props.theme.inputBorderColor};
 background-color: ${(props) => props.theme.inputBgColor};
 border-radius : 6px;
+width: 30rem;
+height: 20rem;
+resize: none;
 &:focus {
   background-color: ${(props) => props.theme.whiteColor};
   border: 1px solid ${(props) => props.theme.inputBorderActiveColor};

--- a/src/frontend/components/MilestoneForm/MilestoneForm.jsx
+++ b/src/frontend/components/MilestoneForm/MilestoneForm.jsx
@@ -1,30 +1,56 @@
-import React from 'react';
+import React, { useReducer, useCallback } from 'react';
 import styled from 'styled-components';
-
+import useFetch from '@Util/useFetch';
 import Button from '@Common/Button';
+import { useHistory } from 'react-router';
 
-const MilestoneForm = () => (
+const MilestoneForm = () => {
+  const inputReducer = (state, action) => {
+    switch (action.type) {
+      case 'title':
+        state.title = action.value;
+        break;
+      case 'dueDate':
+        state.dueDate = action.value;
+        break;
+      case 'description':
+        state.description = action.value;
+        break;
+      default:
+    }
+    return state;
+  };
+  const [inputValue, inputHandler] = useReducer(inputReducer, { title: '', dueDate: '', description: '' });
+  const history = useHistory();
+
+  const submitHandler = async () => {
+    const result = await useFetch('/api/milestones', 'POST', inputValue);
+    history.push('/milestones');
+  };
+
+  return (
       <Main>
           <Content>
             <h2>New Milestone</h2>
             <h4>Create a new milestone</h4>
-            <hr width="100%" height="1"/>
-            <form action="/milestones" method="POST">
-              <h4>title</h4>
-              <TextInput type="text" name="title"></TextInput>
-              <h4>Due date (optional)</h4>
-              <DateInput type="date" name="dueDate"></DateInput>
-              <h4>Description (optional)</h4>
-              <TextareaInput cols="60" rows="20" resize="none" name="description"></TextareaInput>
-              <hr width="100%" height="1"/>
-              <Button
-              text="Create Milestone"
-              />
-            </form>
+            <RowLine/>
+            <h4>title</h4>
+            <TextInput type="text" name="title" onChange={(e) => inputHandler({ type: 'title', value: e.target.value })}></TextInput>
+            <h4>Due date (optional)</h4>
+            <DateInput type="date" name="dueDate" onChange={(e) => inputHandler({ type: 'date', value: e.target.value })}></DateInput>
+            <h4>Description (optional)</h4>
+            <TextareaInput cols="60" rows="20" resize="none" name="description" onChange={(e) => inputHandler({ type: 'description', value: e.target.value })}></TextareaInput>
+            <RowLine/>
+            <Button text="Create Milestone" type="confirm" onClick={submitHandler}/>
           </Content>
       </Main>
+  );
+};
 
-);
+const RowLine = styled.hr`
+  width: 100%;
+  height: 1;
+`;
 
 const FlexColumnBox = `
   display: flex;

--- a/src/frontend/components/MilestoneForm/MilestoneForm.jsx
+++ b/src/frontend/components/MilestoneForm/MilestoneForm.jsx
@@ -43,13 +43,20 @@ const MilestoneForm = () => {
             <h4>Due date (optional)</h4>
             <DateInput type="date" name="dueDate" onChange={(e) => inputHandler({ type: 'date', value: e.target.value })}></DateInput>
             <h4>Description (optional)</h4>
-            <TextareaInput cols="60" rows="20" resize="none" name="description" onChange={(e) => inputHandler({ type: 'description', value: e.target.value })}></TextareaInput>
+            <TextareaInput name="description" onChange={(e) => inputHandler({ type: 'description', value: e.target.value })}></TextareaInput>
             <RowLine/>
-            <Button text="Create Milestone" type="confirm" onClick={submitHandler}/>
+            <ButtonArea>
+              <Button text="Create Milestone" type="confirm" onClick={submitHandler}/>
+            </ButtonArea>
           </Content>
       </Main>
   );
 };
+
+const ButtonArea = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;
 
 const RowLine = styled.hr`
   width: 100%;
@@ -109,6 +116,9 @@ const TextareaInput = styled.textarea`
 border: 1px solid ${(props) => props.theme.inputBorderColor};
 background-color: ${(props) => props.theme.inputBgColor};
 border-radius : 6px;
+width: 30rem;
+height: 20rem;
+resize: none;
 &:focus {
   background-color: ${(props) => props.theme.whiteColor};
   border: 1px solid ${(props) => props.theme.inputBorderActiveColor};

--- a/src/frontend/components/MilestoneForm/MilestoneForm.jsx
+++ b/src/frontend/components/MilestoneForm/MilestoneForm.jsx
@@ -26,7 +26,6 @@ const MilestoneForm = () => {
 
   const submitHandler = async () => {
     if (inputValue.title === null) { alert('제목을 입력해주세요'); } else {
-      console.log(inputValue);
       const result = await useFetch('/api/milestones', 'POST', inputValue);
       history.push('/milestones');
     }

--- a/src/frontend/components/MilestoneForm/MilestoneForm.jsx
+++ b/src/frontend/components/MilestoneForm/MilestoneForm.jsx
@@ -20,12 +20,16 @@ const MilestoneForm = () => {
     }
     return state;
   };
-  const [inputValue, inputHandler] = useReducer(inputReducer, { title: '', dueDate: '', description: '' });
+
+  const [inputValue, inputHandler] = useReducer(inputReducer, { title: null, dueDate: null, description: null });
   const history = useHistory();
 
   const submitHandler = async () => {
-    const result = await useFetch('/api/milestones', 'POST', inputValue);
-    history.push('/milestones');
+    if (inputValue.title === null) { alert('제목을 입력해주세요'); } else {
+      console.log(inputValue);
+      const result = await useFetch('/api/milestones', 'POST', inputValue);
+      history.push('/milestones');
+    }
   };
 
   return (

--- a/src/frontend/components/MilestonePage/MilestonePage.jsx
+++ b/src/frontend/components/MilestonePage/MilestonePage.jsx
@@ -14,21 +14,9 @@ const getMilestoneList = (milestones) => (
   milestones.map((milestone) => (
   <Milestone key={milestone.id} data={milestone}></Milestone>)));
 
-const getOpened = (milestones) => {
-  let count = 0;
-  milestones.forEach((el) => {
-    if (el.isOpened) { count++; }
-  });
-  return count;
-};
+const getOpened = (milestones) => milestones.reduce((pre, curr) => (curr.isOpened ? pre + 1 : pre), 0);
 
-const getClosed = (milestones) => {
-  let count = 0;
-  milestones.forEach((el) => {
-    if (!el.isOpened) { count++; }
-  });
-  return count;
-};
+const getClosed = (milestones) => milestones.reduce((pre, curr) => (curr.isOpened ? pre : pre + 1), 0);
 
 const MilestonePage = () => {
   const [loading, setLoading] = useState(false);


### PR DESCRIPTION
## 구현 내용
#### PR 지적사항 수정
- forEach -> reduce
- styled component를 내부에 두었던 문제
- 숫자를 세어 저장하던 closed, opened 변수 이름 변경 ```closedCount / openedCount```

#### FE
- 목록 페이지
  - 등록된 이슈가 없고, 방금 생성되여 0 Open, 0 Closed, 0% Complete 상태일때 표시되지 않던 버그 수정
  - dueDate가 존재하지 않을 경우 no Due Date를 출력하도록 구현
  - edit 버튼과 new Issue 버튼에 onClick 이벤트 함수구현

- 생성 페이지
  - title 필수 요건을 위해 null일시 alert 메시지와 함께, 입력을 유도
  - <img width="840" alt="스크린샷 2020-11-11 오후 7 53 43" src="https://user-images.githubusercontent.com/55074799/98803112-9e359b00-2457-11eb-8a28-fef8c5746048.png">
  - 버튼 이벤트 등록으로, fetch POST를 전송하도록 구현

- 수정 페이지
  - fetch를 통해 param id에 해당하는 milestone의 정도를 fetch 해오는 기능 구현
  - <img width="359" alt="스크린샷 2020-11-11 오후 7 54 11" src="https://user-images.githubusercontent.com/55074799/98803160-adb4e400-2457-11eb-8453-ddae722366c8.png">
  - (나머지는 구현중)

#### BE
- 1개의 마일스톤에 대한 정보를 return하는 API 생성 (```/api/milestones/:id```)
  - <img width="353" alt="스크린샷 2020-11-11 오후 7 54 36" src="https://user-images.githubusercontent.com/55074799/98803208-bc9b9680-2457-11eb-9465-810e080c3ff1.png">
- 마일스톤 생성 (```/api/milestones POST```)
  - dueDate와 description Optional 하도록 null 처리

