### PR TITLE
드랍다운 켜졌을 때 드랍다운 바깥 클릭 시 드랍다운 창 닫히게 수정

### DIFF
--- a/src/frontend/components/DropdownCover/DropdownCover.jsx
+++ b/src/frontend/components/DropdownCover/DropdownCover.jsx
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+const DropdownCover = styled.div`
+  position: fixed;
+  top:0;
+  left:0;
+  background-color: rgba(0,0,0,0);
+  width: 100%;
+  height: 100%;
+  z-index: 10;
+`;
+
+export default DropdownCover;

--- a/src/frontend/components/DropdownCover/index.js
+++ b/src/frontend/components/DropdownCover/index.js
@@ -1,0 +1,1 @@
+export { default } from './DropdownCover.jsx';

--- a/src/frontend/components/IssuePage/ContentDropDown.jsx
+++ b/src/frontend/components/IssuePage/ContentDropDown.jsx
@@ -19,7 +19,7 @@ const DropDownBox = styled.div`
   color: ${(props) => (props.theme.commonTextColor)};
   box-shadow: 0px 8px 15px ${(props) => (props.theme.shadowColor)};;
   right: 0px;
-  z-index: 10;
+  z-index: 30;
 `;
 
 const DropDownTitle = styled.div`
@@ -45,7 +45,6 @@ const DropDownInputBox = styled.input`
     z-index: 1;
   }
   height: 1.5rem;
-
 `;
 
 const DropDownMenu = styled.div`

--- a/src/frontend/components/IssuePage/ContentFilter.jsx
+++ b/src/frontend/components/IssuePage/ContentFilter.jsx
@@ -1,6 +1,7 @@
 import React, { useReducer } from 'react';
 import styled from 'styled-components';
 import ContentDropDown from '@Components/IssuePage/ContentDropDown';
+import DropDownCover from '@Components/DropdownCover';
 import PropTypes from 'prop-types';
 
 const SortMenuArea = styled.div`
@@ -27,6 +28,7 @@ const ContentFilter = (props) => {
     <SortMenuArea>
       <SortMenuButton onClick={() => setBoxVisible()}>{name}</SortMenuButton>
         <Wrap visible={boxVisible}>
+          <DropDownCover onClick={() => setBoxVisible()}/>
           <ContentDropDown
             isFilter
             filterDispatch={dropDownValues.filterDispatch}

--- a/src/frontend/components/Sidebar/DropDownButton.jsx
+++ b/src/frontend/components/Sidebar/DropDownButton.jsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import ContentDropDown from '@Components/IssuePage/ContentDropDown';
 import GearIcon from '@Images/GearIcon.svg';
 import PropTypes from 'prop-types';
+import DropdownCover from '@Components/DropdownCover/DropDownCover';
 
 const Main = styled.div`
   all:unset;
@@ -37,7 +38,9 @@ const DropDownButton = (props) => {
         <GearIcon />
       </BoxHeader>
       {boxVisible
-      && <ContentDropDown
+      && <DropdownCover onClick={() => setBoxVisible()} /> }
+      {boxVisible
+          && <ContentDropDown
           isFilter={false}
           filterDispatch={dropDownValues.dispatch}
           fetchLink={dropDownValues.fetchLink}


### PR DESCRIPTION
드랍다운 창이 켜지면 window크기의 Cover컴포넌트가 감싸서 드랍다운 바깥을 클릭하면 드랍다운 창이 닫히는 동작이 되도록 추가했습니다.

## 동작
![latest](https://user-images.githubusercontent.com/34783156/98899040-3718f480-24f2-11eb-9688-32572000ae9b.gif)

### Linked issue
closes #162 