### PR TITLE
이슈 상세페이지에서 assignee 추가 삭제, label 추가 삭제를 돕는 API 작성

### DIFF
--- a/src/backend/controllers/issues.js
+++ b/src/backend/controllers/issues.js
@@ -16,11 +16,14 @@ const assigneeFilter = (assignees, name) => assignees.some((assignee) => assigne
 const filterPivotTable = (labelString, assigneeString) => (issue) => {
   try {
     const { labels, assignees } = issue;
-    const labelArray = (typeof (labelString) === 'string' ? [labelString] : labelString);
-    const assigneeArray = (typeof (assigneeString) === 'string' ? [assigneeString] : assigneeString);
+    const labelArray = typeof labelString === 'string' ? [labelString] : labelString;
+    const assigneeArray = typeof assigneeString === 'string' ? [assigneeString] : assigneeString;
     const validateLabels = labelArray.every((title) => labelFilter(labels, title));
     const validateAssignees = assigneeArray.every((username) => assigneeFilter(assignees, username));
-    return (labelString.length === 0 || validateLabels) && (assigneeString.length === 0 || validateAssignees);
+    return (
+      (labelString.length === 0 || validateLabels)
+      && (assigneeString.length === 0 || validateAssignees)
+    );
   } catch (e) {
     console.error('error : ', e);
     return false;
@@ -118,7 +121,9 @@ export const getAllIssues = async (req, res) => {
       ],
       order: [['createDate', 'DESC']],
     });
-    const filteredIssues = foundIssues.filter(filterPivotTable(labelString, assigneeString));
+    const filteredIssues = foundIssues.filter(
+      filterPivotTable(labelString, assigneeString),
+    );
     const labelCount = await db.Label.count();
     const milestoneCount = await db.Milestone.count();
 
@@ -283,7 +288,11 @@ export const postIssue = async (req, res) => {
     const authorId = req.user.get('id');
     const result = await db.sequelize.transaction(async (t) => {
       const {
-        title, content, assignees = [], labels = [], milestoneId,
+        title,
+        content,
+        assignees = [],
+        labels = [],
+        milestoneId,
       } = req.body;
 
       const Issue = {
@@ -313,5 +322,53 @@ export const postIssue = async (req, res) => {
     res.status(200).json({ id: result, message: 'create success' });
   } catch (error) {
     res.status(500).json({ id: null, message: `${error}` });
+  }
+};
+
+export const postAssignee = async (req, res) => {
+  try {
+    const issueId = req.params.id;
+    const { assigneeId } = req.body;
+    await db.Assignee.create({ issueId, assigneeId });
+
+    res.status(200).json({ message: 'assignee success' });
+  } catch (error) {
+    res.status(500).json({ message: `${error}` });
+  }
+};
+
+export const deleteAssignee = async (req, res) => {
+  try {
+    const issueId = req.params.id;
+    const { assigneeId } = req.params;
+    await db.Assignee.destroy({ where: { issueId, assigneeId } });
+
+    res.status(200).json({ message: 'delete success' });
+  } catch (error) {
+    res.status(500).json({ message: `${error}` });
+  }
+};
+
+export const postLabel = async (req, res) => {
+  try {
+    const issueId = req.params.id;
+    const { labelId } = req.body;
+    await db.IssueLabel.create({ issueId, labelId });
+
+    res.status(200).json({ message: 'label success' });
+  } catch (error) {
+    res.status(500).json({ message: `${error}` });
+  }
+};
+
+export const deleteLabel = async (req, res) => {
+  try {
+    const issueId = req.params.id;
+    const { labelId } = req.params;
+    await db.IssueLabel.destroy({ where: { issueId, labelId } });
+
+    res.status(200).json({ message: 'delete success' });
+  } catch (error) {
+    res.status(500).json({ message: `${error}` });
   }
 };

--- a/src/backend/models/IssueLabel.js
+++ b/src/backend/models/IssueLabel.js
@@ -7,16 +7,5 @@ export default (sequelize) => {
     },
   );
 
-  IssueLabel.associate = (models) => {
-    IssueLabel.belongsTo(models.Issue, {
-      as: 'issued',
-      foreignKey: 'id',
-    });
-    IssueLabel.belongsTo(models.Label, {
-      as: 'labelId',
-      foreignKey: 'id',
-    });
-  };
-
   return IssueLabel;
 };

--- a/src/backend/routes/issues.js
+++ b/src/backend/routes/issues.js
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import {
-  getAllIssues, getIssueDetail, modifyIssueStatus, patchIssue, postIssue,
+  getAllIssues, getIssueDetail, modifyIssueStatus, patchIssue, postIssue, postAssignee, deleteAssignee, postLabel, deleteLabel,
 } from '../controllers/issues';
 
 const IssueRouter = Router();
@@ -15,5 +15,13 @@ IssueRouter.patch('/:id', patchIssue);
 IssueRouter.post('/status', modifyIssueStatus);
 // 이슈 작성
 IssueRouter.post('/', postIssue);
+// Detail page에서 Assignee추가
+IssueRouter.post('/:id/assignee', postAssignee);
+// Detail page에서 Assignee삭제
+IssueRouter.delete('/:id/assignee/:assigneeId', deleteAssignee);
+// Detail page에서 Label추가
+IssueRouter.post('/:id/label', postLabel);
+// Detail page에서 Label삭제
+IssueRouter.delete('/:id/label/:labelId', deleteLabel);
 
 export default IssueRouter;


### PR DESCRIPTION
## 개발 내용
* 이슈 assignee 추가 삭제
* 이슈 label 추가 삭제

```javascript
// router/issue.js

// Detail page에서 Assignee추가
IssueRouter.post('/:id/assignee', postAssignee);
// Detail page에서 Assignee삭제
IssueRouter.delete('/:id/assignee/:assigneeId', deleteAssignee);
// Detail page에서 Label추가
IssueRouter.post('/:id/label', postLabel);
// Detail page에서 Label삭제
IssueRouter.delete('/:id/label/:labelId', deleteLabel);
```
개별 요청에 대한 API입니다.


## 추가적으로 생각할 부분
* Naming collision이 발생
-> 양방향 참조를 하다보니 참조키의 값이 겹치는듯?했다. 지우님의 의견대로 associate를 삭제하니 잘 동작.
* 중복된 값이 요청됐을 때 500 에러가 반환된다.
-> 에러가 반환되었을 경우 get요청으로 rerender을 한번 발생시켜주는 것이 낫다.