### PR TITLE
이슈/댓글 작성에서 이미지 첨부 시 loading...이 뜨도록 대응

### DIFF
--- a/src/frontend/util/imgurEventHandler.js
+++ b/src/frontend/util/imgurEventHandler.js
@@ -1,25 +1,37 @@
-export default function imgurHandler(event) {
+export default function imgurHandler(file) {
   return new Promise((resolve) => {
+    let tryCount = 0;
     const reader = new FileReader();
     // eslint-disable-next-line consistent-return
     reader.onloadend = () => {
       const base64 = reader.result;
       if (base64) {
-        fetch('https://api.imgur.com/3/image', {
+        const fetchImgur = fetch('https://api.imgur.com/3/image', {
           method: 'POST',
           headers: {
             Authorization: 'Client-ID 693d1faa8a61999',
             Accept: 'application/json',
           },
           body: base64.split(',')[1].toString(),
-        })
+        });
+        fetchImgur
           .then((response) => response.json())
           .then((response) => {
-            const data = `![](${response.data.link})`;
-            resolve(data);
+            if (!response.success) {
+              tryCount++;
+              if (tryCount < 3) return fetchImgur();
+              return '![imgur 서버 요청이 실패했습니다.]()';
+            }
+            const data = `![${file.name}](${response.data.link})`;
+            return resolve(data);
+          })
+          .catch((err) => {
+            tryCount++;
+            if (tryCount < 3) return fetchImgur();
+            return '![imgur 서버 요청이 실패했습니다.]()';
           });
       }
     };
-    reader.readAsDataURL(event.target.files[0]);
+    reader.readAsDataURL(file);
   });
 }


### PR DESCRIPTION
###### feat(IssueForm): image등록 시 loading...이 표시되게함 3bf97a7
- textarea의 현재 cursor가 있는 position에 `![filename loading...]()`을 표시
- fetch가 끝나면 비동기적으로 그 내용을 markdown으로 replace
  - event handler 내에서 안되서 useEffect()로 빼버렸음
- imgurEventHandler가 받는 type을 event가 아닌 file으로 변경
- imgur server가 busy일 때의 handling
  - 3회까지 fetch 재시도.
###### feat(CommentForm): 코멘트에서도 이미지 첨부되게 대응 4c3ea60
- 복붙함

-----

이번에 이거 추가하려고 state를 여러개 추가했는데 나중에 content랑 묶어서 reducer하나로 묶는게 더 가독성좋아질것같습니다. 지금은 시간없으니 패스요~~~