### PR TITLE
Milestone 관련 페이지 버그 수정 및 기능 추가

### DIFF
--- a/src/frontend/components/Milestone/Milestone.jsx
+++ b/src/frontend/components/Milestone/Milestone.jsx
@@ -3,6 +3,12 @@ import styled from 'styled-components';
 import ProgressBar from '@Components/Milestone/ProgressBar';
 import { useHistory } from 'react-router';
 
+const makeDueDate = (dateObj) => {
+  const month = (dateObj.getMonth() + 1).toString().length === 1 ? `0${dateObj.getMonth() + 1}` : dateObj.getMonth() + 1;
+  const day = dateObj.getDate().toString().length === 1 ? `0${dateObj.getDate()}` : dateObj.getDate();
+  return `${month.toString()}, ${day.toString()}, ${dateObj.getFullYear()}`;
+};
+
 const Milestone = (props) => {
   let {
     closed: closedCount,
@@ -24,12 +30,11 @@ const Milestone = (props) => {
     history.push(`/milestones/edit/${id}`);
   }, [history]);
 
-  const date = dueDate === null ? 'No due Date' : new Date(dueDate);
   return (
       <Main>
         <LeftArea>
           <label>{title}</label>
-          {typeof (date) === 'string' ? date : <label>Due by {date.getMonth()}, {date.getDate()}, {date.getFullYear()}</label>}
+          {dueDate === null ? 'No due Date' : <label>Due by {makeDueDate(new Date(dueDate))}</label>}
           <label>{description}</label>
         </LeftArea>
         <RightArea>

--- a/src/frontend/components/Milestone/Milestone.jsx
+++ b/src/frontend/components/Milestone/Milestone.jsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import styled from 'styled-components';
 import ProgressBar from '@Components/Milestone/ProgressBar';
 import { useHistory } from 'react-router';
+import useFetch from '@Util/useFetch';
 
 const makeDueDate = (dateObj) => {
   const month = (dateObj.getMonth() + 1).toString().length === 1 ? `0${dateObj.getMonth() + 1}` : dateObj.getMonth() + 1;
@@ -30,6 +31,13 @@ const Milestone = (props) => {
     history.push(`/milestones/edit/${id}`);
   }, [history]);
 
+  const deleteHandler = async (e) => {
+    if (confirm(`[${title}] 마일스톤을 삭제하시겠습니까?`)) {
+      const result = await useFetch(`/api/milestones/${id}`, 'DELETE');
+      location.reload();
+    }
+  };
+
   return (
       <Main>
         <LeftArea>
@@ -47,7 +55,7 @@ const Milestone = (props) => {
           <RowArea>
             <MarginButton onClick={moveToEdit}>Edit</MarginButton>
             <MarginButton>Close</MarginButton>
-            <MarginButton>Delete</MarginButton>
+            <MarginButton onClick={deleteHandler}>Delete</MarginButton>
           </RowArea>
         </RightArea>
       </Main>

--- a/src/frontend/components/MilestoneEdit/MilestoneEdit.jsx
+++ b/src/frontend/components/MilestoneEdit/MilestoneEdit.jsx
@@ -11,7 +11,9 @@ import useFetch from '@Util/useFetch';
 const makeDueDate = (dateObj) => {
   const month = (dateObj.getMonth() + 1).toString().length === 1 ? `0${dateObj.getMonth() + 1}` : dateObj.getMonth() + 1;
   const day = dateObj.getDate().toString().length === 1 ? `0${dateObj.getDate()}` : dateObj.getDate();
-  return `${dateObj.getFullYear()}-${month.toString()}-${day.toString()}`;
+  return `${dateObj.getFullYear()}-${month.toString()}-${day.toString()}` !== '1970-01-01'
+    ? `${dateObj.getFullYear()}-${month.toString()}-${day.toString()}`
+    : '';
 };
 
 const MilestoneEdit = () => {

--- a/src/frontend/components/MilestoneEdit/MilestoneEdit.jsx
+++ b/src/frontend/components/MilestoneEdit/MilestoneEdit.jsx
@@ -9,7 +9,7 @@ import { useHistory, useParams } from 'react-router';
 import useFetch from '@Util/useFetch';
 
 const makeDueDate = (dateObj) => {
-  const month = dateObj.getMonth().toString().length === 1 ? `0${dateObj.getMonth()}` : dateObj.getMonth();
+  const month = (dateObj.getMonth() + 1).toString().length === 1 ? `0${dateObj.getMonth() + 1}` : dateObj.getMonth() + 1;
   const day = dateObj.getDate().toString().length === 1 ? `0${dateObj.getDate()}` : dateObj.getDate();
   return `${dateObj.getFullYear()}-${month.toString()}-${day.toString()}`;
 };
@@ -49,6 +49,13 @@ const MilestoneEdit = () => {
     }
   }, [loading]);
 
+  const submitHandler = async () => {
+    if (inputValue.title === null) { alert('제목을 입력해주세요'); } else {
+      const result = await useFetch(`/api/milestones/${id}`, 'PATCH', inputValue);
+      history.push('/milestones');
+    }
+  };
+
   const onChangeTitleHandle = (e) => {
     inputHandler({ type: 'title', value: e.target.value });
   };
@@ -79,9 +86,9 @@ const MilestoneEdit = () => {
               <TextareaInput name="description" value={inputValue.description} onChange={onChangeDescriptionHandle}></TextareaInput>
               <RowLine/>
               <ButtonArea>
-                <Button text="Cancel" type="cancel"/>
+                <Button text="Cancel" type="cancel" onClick={moveToMilestones}/>
                 <Button text="Close Milestone" type="cancel"/>
-                <Button text="Save Changes" />
+                <Button text="Save Changes" onClick={submitHandler}/>
               </ButtonArea>
           </Content>
       </Main>

--- a/src/frontend/components/MilestoneEdit/MilestoneEdit.jsx
+++ b/src/frontend/components/MilestoneEdit/MilestoneEdit.jsx
@@ -8,6 +8,12 @@ import Button from '@Common/Button';
 import { useHistory, useParams } from 'react-router';
 import useFetch from '@Util/useFetch';
 
+const makeDueDate = (dateObj) => {
+  const month = dateObj.getMonth().toString().length === 1 ? `0${dateObj.getMonth()}` : dateObj.getMonth();
+  const day = dateObj.getDate().toString().length === 1 ? `0${dateObj.getDate()}` : dateObj.getDate();
+  return `${dateObj.getFullYear()}-${month.toString()}-${day.toString()}`;
+};
+
 const MilestoneEdit = () => {
   const history = useHistory();
   const { id } = useParams();
@@ -21,29 +27,20 @@ const MilestoneEdit = () => {
     history.push('/milestones');
   }, [history]);
 
-  const inputReducer = (state, action) => {
-    switch (action.type) {
-      case 'title':
-        state.title = action.value;
-        break;
-      case 'dueDate':
-        state.dueDate = action.value;
-        break;
-      case 'description':
-        state.description = action.value;
-        break;
-      default:
-    }
-    return state;
-  };
+  const inputReducer = (state, action) => ({
+    ...state,
+    [action.type]: action.value,
+  });
 
-  const [inputValue, inputHandler] = useReducer(inputReducer, { title: null, dueDate: null, description: null });
+  const [inputValue, inputHandler] = useReducer(inputReducer, {
+    title: null, dueDate: null, description: null,
+  });
 
   useEffect(async () => {
     if (!loading) {
       const result = await useFetch(`/api/milestones/${id}`, 'GET');
       const dateObj = new Date(result.milestones[0].dueDate);
-      const dueDate = `${dateObj.getFullYear()}-${dateObj.getMonth()}-${dateObj.getDate()}`;
+      const dueDate = makeDueDate(dateObj);
 
       inputHandler({ type: 'title', value: result.milestones[0].title });
       inputHandler({ type: 'dueDate', value: dueDate.toString() });
@@ -51,6 +48,18 @@ const MilestoneEdit = () => {
       setLoading(true);
     }
   }, [loading]);
+
+  const onChangeTitleHandle = (e) => {
+    inputHandler({ type: 'title', value: e.target.value });
+  };
+
+  const onChangeDuedateHandle = (e) => {
+    inputHandler({ type: 'dueDate', value: e.target.value });
+  };
+
+  const onChangeDescriptionHandle = (e) => {
+    inputHandler({ type: 'description', value: e.target.value });
+  };
 
   return (
       <Main>
@@ -63,11 +72,11 @@ const MilestoneEdit = () => {
             </MenuBox>
               <RowLine/>
               <h4>title</h4>
-              <TextInput type="text" name="title" value={inputValue.title} onChange={(e) => inputHandler({ type: 'title', value: e.target.value })}></TextInput>
+              <TextInput type="text" name="title" value={inputValue.title} onChange={onChangeTitleHandle}></TextInput>
               <h4>Due date (optional)</h4>
-              <DateInput type="date" name="dueDate" value={inputValue.dueDate} onChange={(e) => inputHandler({ type: 'dueDate', value: e.target.value })}></DateInput>
+              <DateInput type="date" name="dueDate" value={inputValue.dueDate} onChange={onChangeDuedateHandle}></DateInput>
               <h4>Description (optional)</h4>
-              <TextareaInput name="description" value={inputValue.description} onChange={(e) => inputHandler({ type: 'description', value: e.target.value })}></TextareaInput>
+              <TextareaInput name="description" value={inputValue.description} onChange={onChangeDescriptionHandle}></TextareaInput>
               <RowLine/>
               <ButtonArea>
                 <Button text="Cancel" type="cancel"/>

--- a/src/frontend/components/MilestoneEdit/MilestoneEdit.jsx
+++ b/src/frontend/components/MilestoneEdit/MilestoneEdit.jsx
@@ -33,7 +33,7 @@ const MilestoneEdit = () => {
   });
 
   const [inputValue, inputHandler] = useReducer(inputReducer, {
-    title: null, dueDate: null, description: null,
+    title: '', dueDate: null, description: null,
   });
 
   useEffect(async () => {
@@ -88,7 +88,7 @@ const MilestoneEdit = () => {
               <ButtonArea>
                 <Button text="Cancel" type="cancel" onClick={moveToMilestones}/>
                 <Button text="Close Milestone" type="cancel"/>
-                <Button text="Save Changes" onClick={submitHandler}/>
+                <Button text="Save Changes" valid={inputValue.title !== ''}onClick={submitHandler}/>
               </ButtonArea>
           </Content>
       </Main>

--- a/src/frontend/components/MilestoneForm/MilestoneForm.jsx
+++ b/src/frontend/components/MilestoneForm/MilestoneForm.jsx
@@ -5,23 +5,12 @@ import Button from '@Common/Button';
 import { useHistory } from 'react-router';
 
 const MilestoneForm = () => {
-  const inputReducer = (state, action) => {
-    switch (action.type) {
-      case 'title':
-        state.title = action.value;
-        break;
-      case 'dueDate':
-        state.dueDate = action.value;
-        break;
-      case 'description':
-        state.description = action.value;
-        break;
-      default:
-    }
-    return state;
-  };
+  const inputReducer = (state, action) => ({
+    ...state,
+    [action.type]: action.value,
+  });
 
-  const [inputValue, inputHandler] = useReducer(inputReducer, { title: null, dueDate: null, description: null });
+  const [inputValue, inputHandler] = useReducer(inputReducer, { title: '', dueDate: null, description: null });
   const history = useHistory();
 
   const submitHandler = async () => {
@@ -31,6 +20,18 @@ const MilestoneForm = () => {
     }
   };
 
+  const onChangeTitleHandle = (e) => {
+    inputHandler({ type: 'title', value: e.target.value });
+  };
+
+  const onChangeDuedateHandle = (e) => {
+    inputHandler({ type: 'dueDate', value: e.target.value });
+  };
+
+  const onChangeDescriptionHandle = (e) => {
+    inputHandler({ type: 'description', value: e.target.value });
+  };
+
   return (
       <Main>
           <Content>
@@ -38,14 +39,14 @@ const MilestoneForm = () => {
             <h4>Create a new milestone</h4>
             <RowLine/>
             <h4>title</h4>
-            <TextInput type="text" name="title" onChange={(e) => inputHandler({ type: 'title', value: e.target.value })}></TextInput>
+            <TextInput type="text" name="title" onChange={onChangeTitleHandle}></TextInput>
             <h4>Due date (optional)</h4>
-            <DateInput type="date" name="dueDate" onChange={(e) => inputHandler({ type: 'dueDate', value: e.target.value })}></DateInput>
+            <DateInput type="date" name="dueDate" onChange={onChangeDuedateHandle}></DateInput>
             <h4>Description (optional)</h4>
-            <TextareaInput name="description" onChange={(e) => inputHandler({ type: 'description', value: e.target.value })}></TextareaInput>
+            <TextareaInput name="description" onChange={onChangeDescriptionHandle}></TextareaInput>
             <RowLine/>
             <ButtonArea>
-              <Button text="Create Milestone" type="confirm" onClick={submitHandler}/>
+              <Button text="Create Milestone" type="confirm" valid={inputValue.title !== ''} onClick={submitHandler}/>
             </ButtonArea>
           </Content>
       </Main>

--- a/src/frontend/components/MilestoneForm/MilestoneForm.jsx
+++ b/src/frontend/components/MilestoneForm/MilestoneForm.jsx
@@ -40,7 +40,7 @@ const MilestoneForm = () => {
             <h4>title</h4>
             <TextInput type="text" name="title" onChange={(e) => inputHandler({ type: 'title', value: e.target.value })}></TextInput>
             <h4>Due date (optional)</h4>
-            <DateInput type="date" name="dueDate" onChange={(e) => inputHandler({ type: 'date', value: e.target.value })}></DateInput>
+            <DateInput type="date" name="dueDate" onChange={(e) => inputHandler({ type: 'dueDate', value: e.target.value })}></DateInput>
             <h4>Description (optional)</h4>
             <TextareaInput name="description" onChange={(e) => inputHandler({ type: 'description', value: e.target.value })}></TextareaInput>
             <RowLine/>


### PR DESCRIPTION
## 구현 내용
Edit 페이지에서 MIlestone의 날짜가 입력되지 않은 경우 1970-01-01로 표시되던 문제를 수정했습니다

from
<img width="254" alt="스크린샷 2020-11-12 오후 5 28 36" src="https://user-images.githubusercontent.com/55074799/98915007-b2879f80-250c-11eb-95e8-610ef0ebe6fd.png">

to
<img width="200" alt="스크린샷 2020-11-12 오후 5 30 17" src="https://user-images.githubusercontent.com/55074799/98915061-c16e5200-250c-11eb-95c0-607e160f1772.png">


Milestone Create, Edit, Cancel 버튼 기능을 구현하였습니다

Edit, Create 페이지에서 input의 Value가 실시간으로 변하지 않던 문제를 수정했습니다

Date 객체의 getMonth()시 리턴값이 1만큼 작아(ex. 10월 -> 9) 이를 보완하였습니다

reducer의 경우, state 객체의 변경을 확인하려면 새로운 객체를 리턴하는 방식으로 사용해야 합니다
```javascript
  const [inputValue, inputHandler] = useReducer(inputReducer, {
    title: '', dueDate: null, description: null,
  });

// 올바른 방법
  const inputReducer = (state, action) => ({
    ...state,
    [action.type]: action.value,
  });

// 틀린 방법
  const inputReducer = (state, action) => ({
    if(action.type === 'title'){
       state.title = action.value;
    }
  });
```

버튼의 Valid 옵션을 사용하여 필수 요건인 Title을 적지 않으면 비활성화 되도록 구현했습니다

![Nov-12-2020 17-14-23](https://user-images.githubusercontent.com/55074799/98913325-8f5bf080-250a-11eb-8fc6-f95d83363477.gif)


Delete 버튼 클릭시 삭제 기능을 구현하였습니다

![Nov-12-2020 17-59-07](https://user-images.githubusercontent.com/55074799/98918363-e06ee300-2510-11eb-9303-7d97ff5d08b2.gif)

### Related Issues
close : #58  #60 